### PR TITLE
Add XML docs for cmdlets

### DIFF
--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -8,32 +8,59 @@ using Globalping;
 namespace Globalping.PowerShell;
 
 /// <summary>Base class for Globalping measurement cmdlets.</summary>
-/// <para>Provides common parameters shared between Start-Globalping commands.</para>
+/// <para>Derived cmdlets send measurement requests to the Globalping service
+/// and return structured results.</para>
+/// <para>The common parameters defined here control target host, probe
+/// selection and authentication.</para>
+/// <seealso href="https://github.com/EvotecIT/Globalping/tree/main/Globalping.Examples">Repository examples</seealso>
+/// <example>
+///   <summary>Ping from Germany</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingPing -Target "example.com" -SimpleLocations "DE"</code>
+///   <para>Runs a ping measurement from German probes.</para>
+/// </example>
+/// <example>
+///   <summary>HTTP request with live updates</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates</code>
+///   <para>Requests three probes and streams intermediate results.</para>
+/// </example>
 public abstract class StartGlobalpingBaseCommand : PSCmdlet
 {
     protected abstract MeasurementType Type { get; }
 
-    /// <para>Target host name, address or URL.</para>
+    /// <para>Target host name, IP address or URL to test.</para>
+    /// <para>The target string is passed verbatim to the underlying
+    /// measurement API.</para>
     [Parameter(Mandatory = true)]
     public string Target { get; set; } = string.Empty;
 
     /// <para>Detailed location definitions for probes.</para>
+    /// <para>Each <see cref="LocationRequest"/> may specify city, country,
+    /// ASN or provider details.</para>
     [Parameter]
     public LocationRequest[]? Locations { get; set; }
 
     /// <para>Short location identifiers such as city or country codes.</para>
+    /// <para>Two-letter strings are treated as ISO country codes. Longer
+    /// values map to the "magic" location syntax used by the API.</para>
     [Parameter]
     public string[]? SimpleLocations { get; set; }
 
     /// <para>Maximum number of probes to use.</para>
+    /// <para>If omitted the cmdlet estimates a value based on provided
+    /// locations.</para>
     [Parameter]
     public int? Limit { get; set; }
 
-    /// <para>Request progress updates while measurement runs.</para>
+    /// <para>Request progress updates while the measurement runs.</para>
+    /// <para>When set the API streams partial results that are written as they
+    /// arrive.</para>
     [Parameter]
     public SwitchParameter InProgressUpdates { get; set; }
 
     /// <para>API key used to authenticate with Globalping.</para>
+    /// <para>Anonymous requests may be rate limited.</para>
     [Parameter]
     [Alias("Token")]
     public string? ApiKey { get; set; }

--- a/Globalping.PowerShell/StartGlobalpingDnsCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingDnsCommand.cs
@@ -4,12 +4,18 @@ using Globalping;
 namespace Globalping.PowerShell;
 
 /// <summary>Start a DNS lookup using Globalping.</summary>
-/// <para>Queries DNS records from remote probes.</para>
+/// <para>Queries DNS records from remote probes and converts them to <see cref="DnsRecordResult"/> objects.</para>
 /// <example>
 ///   <summary>Resolve A record</summary>
 ///   <prefix>PS> </prefix>
 ///   <code>Start-GlobalpingDns -Target "evotec.xyz"</code>
 ///   <para>Returns DNS records from available probes.</para>
+/// </example>
+/// <example>
+///   <summary>Use custom resolver</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingDns -Target "cloudflare.com" -Options @{ Resolver = "8.8.8.8" }</code>
+///   <para>Sends the DNS query using the Google public resolver.</para>
 /// </example>
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingDns")]
 [OutputType(typeof(DnsRecordResult))]
@@ -18,15 +24,18 @@ namespace Globalping.PowerShell;
 public class StartGlobalpingDnsCommand : StartGlobalpingBaseCommand
 {
     /// <para>Return the raw measurement response.</para>
+    /// <para>Use this switch to inspect the <see cref="MeasurementResponse"/> object without conversion.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
     /// <para>Output DNS results in classic text form.</para>
+    /// <para>The original text returned by the resolver is emitted.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
     /// <para>Additional DNS options for the request.</para>
+    /// <para>Allows custom resolver, query type or trace options.</para>
     [Parameter]
     public DnsOptions? Options { get; set; }
 

--- a/Globalping.PowerShell/StartGlobalpingHttpCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingHttpCommand.cs
@@ -4,12 +4,18 @@ using Globalping;
 namespace Globalping.PowerShell;
 
 /// <summary>Start an HTTP request using Globalping.</summary>
-/// <para>Sends an HTTP request from remote probes and returns the responses.</para>
+/// <para>Sends an HTTP request from remote probes and returns <see cref="HttpResponseResult"/> objects.</para>
 /// <example>
 ///   <summary>Fetch a webpage</summary>
 ///   <prefix>PS> </prefix>
 ///   <code>Start-GlobalpingHttp -Target "evotec.xyz" -SimpleLocations "Krakow+PL"</code>
 ///   <para>Returns HTTP response details from the Krakow probe.</para>
+/// </example>
+/// <example>
+///   <summary>Headers only</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingHttp -Target "https://example.com" -HeadersOnly</code>
+///   <para>Outputs only the HTTP headers from each probe.</para>
 /// </example>
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingHttp")]
 [OutputType(typeof(HttpResponseResult))]
@@ -18,19 +24,23 @@ namespace Globalping.PowerShell;
 public class StartGlobalpingHttpCommand : StartGlobalpingBaseCommand
 {
     /// <para>Return the raw measurement response.</para>
+    /// <para>The full <see cref="MeasurementResponse"/> is emitted without conversion.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
     /// <para>Output HTTP results in classic text form.</para>
+    /// <para>Each probe returns the textual output of the underlying HTTP tool.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
     /// <para>Emit only HTTP headers from each response.</para>
+    /// <para>Ignores the body content from the probes.</para>
     [Parameter]
     public SwitchParameter HeadersOnly { get; set; }
 
     /// <para>Additional HTTP options for the request.</para>
+    /// <para>Allows setting request method, headers or body.</para>
     [Parameter]
     public HttpOptions? Options { get; set; }
 

--- a/Globalping.PowerShell/StartGlobalpingMtrCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingMtrCommand.cs
@@ -11,6 +11,12 @@ namespace Globalping.PowerShell;
 ///   <code>Start-GlobalpingMtr -Target "evotec.xyz"</code>
 ///   <para>Produces hop statistics for the target.</para>
 /// </example>
+/// <example>
+///   <summary>Limit packets</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingMtr -Target "example.com" -Options @{ Packets = 3 }</code>
+///   <para>Configures the probe to send three packets per hop.</para>
+/// </example>
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingMtr")]
 [OutputType(typeof(MtrHopResult))]
 [OutputType(typeof(string))]
@@ -18,15 +24,18 @@ namespace Globalping.PowerShell;
 public class StartGlobalpingMtrCommand : StartGlobalpingBaseCommand
 {
     /// <para>Return the raw measurement response.</para>
+    /// <para>Useful when converting the result to custom objects.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
     /// <para>Output MTR results in classic text form.</para>
+    /// <para>The text output mirrors the behaviour of the MTR command line tool.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
     /// <para>Additional MTR options for the request.</para>
+    /// <para>Use to configure packet count or other low level parameters.</para>
     [Parameter]
     public MtrOptions? Options { get; set; }
 

--- a/Globalping.PowerShell/StartGlobalpingPingCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingPingCommand.cs
@@ -4,12 +4,25 @@ using Globalping;
 namespace Globalping.PowerShell;
 
 /// <summary>Start a ping measurement using Globalping.</summary>
-/// <para>Executes ping from selected probes and returns timing results or raw data.</para>
+/// <para>Instructs remote probes to send ICMP echo requests to the specified target.</para>
+/// <para>The cmdlet outputs <see cref="PingTimingResult"/> objects, raw results or classic text depending on the selected parameters.</para>
 /// <example>
 ///   <summary>Ping from multiple locations</summary>
 ///   <prefix>PS> </prefix>
 ///   <code>Start-GlobalpingPing -Target "evotec.xyz" -SimpleLocations "DE", "US"</code>
 ///   <para>Runs ping from probes in Germany and the United States.</para>
+/// </example>
+/// <example>
+///   <summary>Request five packets</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingPing -Target "example.com" -SimpleLocations "PL" -Options @{ Packets = 5 }</code>
+///   <para>Uses <see cref="PingOptions"/> to set the packet count.</para>
+/// </example>
+/// <example>
+///   <summary>Output classic text</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingPing -Target "example.com" -Classic</code>
+///   <para>Displays the raw ping output returned by the probe.</para>
 /// </example>
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingPing")]
 [OutputType(typeof(PingTimingResult))]
@@ -18,15 +31,18 @@ namespace Globalping.PowerShell;
 public class StartGlobalpingPingCommand : StartGlobalpingBaseCommand
 {
     /// <para>Return the unprocessed measurement response.</para>
+    /// <para>When set the cmdlet outputs the <see cref="MeasurementResponse"/> object returned by the API.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
-    /// <para>Output ping results in classic text format.</para>
+    /// <para>Output ping results in the classic text format.</para>
+    /// <para>Each probe returns the textual output of its ping utility.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
     /// <para>Additional ping options sent with the request.</para>
+    /// <para>Use this to configure packet count or other low level settings.</para>
     [Parameter]
     public PingOptions? Options { get; set; }
 

--- a/Globalping.PowerShell/StartGlobalpingTracerouteCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingTracerouteCommand.cs
@@ -4,12 +4,18 @@ using Globalping;
 namespace Globalping.PowerShell;
 
 /// <summary>Start a traceroute measurement using Globalping.</summary>
-/// <para>Runs traceroute from specified probes and returns hop details or raw output.</para>
+/// <para>Collects hop information from remote probes with optional classic text output.</para>
 /// <example>
 ///   <summary>Traceroute to a host</summary>
 ///   <prefix>PS> </prefix>
 ///   <code>Start-GlobalpingTraceroute -Target "evotec.xyz"</code>
 ///   <para>Performs traceroute to the target host.</para>
+/// </example>
+/// <example>
+///   <summary>Return raw output</summary>
+///   <prefix>PS> </prefix>
+///   <code>Start-GlobalpingTraceroute -Target "example.com" -Classic</code>
+///   <para>Writes the traceroute text produced by the probe.</para>
 /// </example>
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingTraceroute")]
 [OutputType(typeof(TracerouteHopResult))]
@@ -18,15 +24,18 @@ namespace Globalping.PowerShell;
 public class StartGlobalpingTracerouteCommand : StartGlobalpingBaseCommand
 {
     /// <para>Return the full measurement response.</para>
+    /// <para>The object is not converted to individual hops.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
     /// <para>Output traceroute in classic text form.</para>
+    /// <para>Returns the text produced by the traceroute utility.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
     /// <para>Additional traceroute options for the request.</para>
+    /// <para>Allows packet size or protocol customization.</para>
     [Parameter]
     public TracerouteOptions? Options { get; set; }
 


### PR DESCRIPTION
## Summary
- document cmdlet classes and parameters with XML comments

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj`
- `pwsh -NoLogo -NoProfile -Command ./Module/Globalping.Tests.ps1` *(fails: no test files)*

------
https://chatgpt.com/codex/tasks/task_e_684dc0488058832e90a9b6c54669e862