### PR TITLE
Add extended location filters

### DIFF
--- a/Globalping/MeasurementRequestBuilder.cs
+++ b/Globalping/MeasurementRequestBuilder.cs
@@ -24,6 +24,48 @@ public class MeasurementRequestBuilder
         return AddLocation(loc);
     }
 
+    public MeasurementRequestBuilder AddContinent(string continent, int? limit = null)
+    {
+        var loc = new LocationRequest { Continent = continent, Limit = limit };
+        return AddLocation(loc);
+    }
+
+    public MeasurementRequestBuilder AddRegion(string region, int? limit = null)
+    {
+        var loc = new LocationRequest { Region = region, Limit = limit };
+        return AddLocation(loc);
+    }
+
+    public MeasurementRequestBuilder AddState(string state, int? limit = null)
+    {
+        var loc = new LocationRequest { State = state, Limit = limit };
+        return AddLocation(loc);
+    }
+
+    public MeasurementRequestBuilder AddCity(string city, int? limit = null)
+    {
+        var loc = new LocationRequest { City = city, Limit = limit };
+        return AddLocation(loc);
+    }
+
+    public MeasurementRequestBuilder AddAsn(int asn, int? limit = null)
+    {
+        var loc = new LocationRequest { Asn = asn, Limit = limit };
+        return AddLocation(loc);
+    }
+
+    public MeasurementRequestBuilder AddNetwork(string network, int? limit = null)
+    {
+        var loc = new LocationRequest { Network = network, Limit = limit };
+        return AddLocation(loc);
+    }
+
+    public MeasurementRequestBuilder AddTags(IEnumerable<string> tags, int? limit = null)
+    {
+        var loc = new LocationRequest { Tags = new List<string>(tags), Limit = limit };
+        return AddLocation(loc);
+    }
+
     public MeasurementRequestBuilder AddMagic(string magic)
     {
         var loc = new LocationRequest { Magic = magic };

--- a/Globalping/Models/LocationRequest.cs
+++ b/Globalping/Models/LocationRequest.cs
@@ -1,14 +1,36 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Globalping;
 
 public class LocationRequest {
+    [JsonPropertyName("continent")]
+    public string? Continent { get; set; }
+
+    [JsonPropertyName("region")]
+    public string? Region { get; set; }
+
     [JsonPropertyName("country")]
     public string? Country { get; set; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+
+    [JsonPropertyName("city")]
+    public string? City { get; set; }
 
     [JsonPropertyName("limit")]
     public int? Limit { get; set; } // Optional limit for probes
 
     [JsonPropertyName("magic")]
     public string? Magic { get; set; } // For "magic" location requests
+
+    [JsonPropertyName("asn")]
+    public int? Asn { get; set; }
+
+    [JsonPropertyName("network")]
+    public string? Network { get; set; }
+
+    [JsonPropertyName("tags")]
+    public List<string>? Tags { get; set; }
 }


### PR DESCRIPTION
## Summary
- add new location fields on `LocationRequest`
- support new fields with helper methods in `MeasurementRequestBuilder`

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684dc6384ae0832ebeee9b1a51926924