### PR TITLE
Limit CI triggers to master

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -3,7 +3,7 @@ name: Test .NET Libraries
 on:
   push:
     branches:
-      - '**'
+      - master
     paths-ignore:
       - '*.md'
       - 'Docs/**'
@@ -11,7 +11,7 @@ on:
       - '.gitignore'
   pull_request:
     branches:
-      - '**'
+      - master
 
 env:
   DOTNET_VERSION: '8.x'

--- a/.github/workflows/test-powershell-module.yml
+++ b/.github/workflows/test-powershell-module.yml
@@ -4,7 +4,7 @@ name: Test PowerShell Module (All)
 on:
   push:
     branches:
-      - '**'
+      - master
     paths-ignore:
       - '*.md'
       - 'Docs/**'
@@ -12,7 +12,7 @@ on:
       - '.gitignore'
   pull_request:
     branches:
-      - '**'
+      - master
 
 env:
   DOTNET_VERSION: '8.x'


### PR DESCRIPTION
## Summary
- restrict test-dotnet and test-powershell-module workflows to master branches

## Testing
- `dotnet test`
- `pwsh -NoLogo -Command ./Module/Globalping.Tests.ps1` *(fails: manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_684dc9629798832eb9122f5bd836de92