### PR TITLE
Add Locations and Limit to MeasurementResponse

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public sealed class MeasurementResponseDeserializationTests
+{
+    [Fact]
+    public void DeserializesLocationsAndLimit()
+    {
+        var json = """
+        {
+            "id": "123",
+            "type": "ping",
+            "status": "finished",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "updatedAt": "2024-01-01T00:01:00Z",
+            "target": "example.com",
+            "probesCount": 1,
+            "locations": [ { "country": "DE", "limit": 1 } ],
+            "limit": 1,
+            "results": []
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        Assert.NotNull(response);
+        Assert.NotNull(response!.Locations);
+        Assert.Single(response.Locations!);
+        Assert.Equal("DE", response.Locations![0].Country);
+        Assert.Equal(1, response.Locations![0].Limit);
+        Assert.Equal(1, response.Limit);
+    }
+}

--- a/Globalping/Responses/MeasurementResponse.cs
+++ b/Globalping/Responses/MeasurementResponse.cs
@@ -29,6 +29,12 @@ public class MeasurementResponse {
     [JsonPropertyName("measurementOptions")]
     public MeasurementOptions? MeasurementOptions { get; set; }
 
+    [JsonPropertyName("locations")]
+    public List<LocationRequest>? Locations { get; set; }
+
+    [JsonPropertyName("limit")]
+    public int? Limit { get; set; }
+
     [JsonPropertyName("results")]
     public List<Result>? Results { get; set; }
 }


### PR DESCRIPTION
## Summary
- add `Locations` and `Limit` properties to measurement response models
- unit test deserializing new response fields

## Testing
- `dotnet build Globalping.sln -c Release`
- `dotnet test Globalping.Tests/Globalping.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684dcc5e97e0832e81a85400f0e93bba