### PR TITLE
Add HttpRequestOptions and update HTTP examples

### DIFF
--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -1,4 +1,5 @@
 using System;
+using Globalping;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -12,7 +13,14 @@ public static class ExecuteHttpExample
             .WithType(MeasurementType.Http)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new HttpOptions());
+            .WithMeasurementOptions(new HttpOptions
+            {
+                Request = new HttpRequestOptions
+                {
+                    Method = "GET",
+                    Path = "/"
+                }
+            });
 
         var request = builder.Build();
         request.InProgressUpdates = false;

--- a/Globalping/Models/HttpOptions.cs
+++ b/Globalping/Models/HttpOptions.cs
@@ -1,4 +1,3 @@
-﻿using HttpRequest = System.Net.Http.HttpRequestMessage;
 using System.Text.Json.Serialization;
 
 namespace Globalping;
@@ -6,7 +5,7 @@ namespace Globalping;
 
 public class HttpOptions : IMeasurementOptions {
     [JsonPropertyName("request")]
-    public HttpRequest Request { get; set; } = new HttpRequest();
+    public HttpRequestOptions Request { get; set; } = new HttpRequestOptions();
 
     [JsonPropertyName("resolver")]
     public string? Resolver { get; set; }

--- a/Globalping/Models/HttpRequestOptions.cs
+++ b/Globalping/Models/HttpRequestOptions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+public class HttpRequestOptions
+{
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+
+    [JsonPropertyName("query")]
+    public string? Query { get; set; }
+
+    [JsonPropertyName("method")]
+    public string Method { get; set; } = "HEAD";
+
+    [JsonPropertyName("headers")]
+    public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
## Summary
- introduce `HttpRequestOptions` for HTTP measurements
- use `HttpRequestOptions` within `HttpOptions`
- update HTTP example to build an `HttpRequestOptions` request

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_684dcc7133a0832e8aab6ff692d1cfe1