### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -53,6 +53,11 @@ jobs:
           name: coverage-reports-windows
           path: '**/coverage.cobertura.xml'
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: '**/coverage.cobertura.xml'
+
   test-ubuntu:
     name: 'Ubuntu'
     runs-on: ubuntu-latest
@@ -81,6 +86,18 @@ jobs:
           name: test-results-ubuntu
           path: '**/*.trx'
 
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports-ubuntu
+          path: '**/coverage.cobertura.xml'
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: '**/coverage.cobertura.xml'
+
   test-macos:
     name: 'macOS'
     runs-on: macos-latest
@@ -108,3 +125,15 @@ jobs:
         with:
           name: test-results-macos
           path: '**/*.trx'
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-reports-macos
+          path: '**/coverage.cobertura.xml'
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: '**/coverage.cobertura.xml'

--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,6 @@
 <p align="center">
   <a href="https://github.com/EvotecIT/Globalping/actions/workflows/dotnet-tests.yml"><img src="https://github.com/EvotecIT/Globalping/actions/workflows/dotnet-tests.yml/badge.svg"></a>
+  <a href="https://codecov.io/gh/EvotecIT/Globalping"><img src="https://codecov.io/gh/EvotecIT/Globalping/branch/master/graph/badge.svg" /></a>
   <a href="https://www.powershellgallery.com/packages/Globalping"><img src="https://img.shields.io/powershellgallery/p/Globalping.svg"></a>
   <a href="https://github.com/EvotecIT/Globalping"><img src="https://img.shields.io/github/languages/top/evotecit/Globalping.svg"></a>
   <a href="https://github.com/EvotecIT/Globalping"><img src="https://img.shields.io/github/languages/code-size/evotecit/Globalping.svg"></a>


### PR DESCRIPTION
## Summary
- collect coverage on all dotnet test jobs
- upload coverage to Codecov
- show Codecov badge in README

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684dce427078832e8561d697b2a141fe