### PR TITLE
Add option to reuse locations from previous measurement

### DIFF
--- a/Globalping.Examples/Examples/BuildRequestExample.cs
+++ b/Globalping.Examples/Examples/BuildRequestExample.cs
@@ -58,5 +58,11 @@ public static class BuildRequestExample
                 Resolver = "8.8.8.8"
             });
         ConsoleHelpers.WriteJson(builder.Build(), "Request 6");
+
+        builder = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .ReuseLocationsFromId("previous-id");
+        ConsoleHelpers.WriteJson(builder.Build(), "Request 7");
     }
 }

--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -41,6 +41,10 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
     [Parameter]
     public LocationRequest[]? Locations { get; set; }
 
+    /// <summary>Reuse probe locations from a previous measurement.</summary>
+    [Parameter]
+    public string? ReuseLocationsFromId { get; set; }
+
     /// <para>Short location identifiers such as city or country codes.</para>
     /// <para>Two-letter strings are treated as ISO country codes. Longer
     /// values map to the "magic" location syntax used by the API.</para>
@@ -74,9 +78,10 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
 
         int? limit = Limit;
         var calculateLimit = !MyInvocation.BoundParameters.ContainsKey(nameof(Limit));
-        var hasLocationLimits = Locations is not null && Locations.Any(l => l.Limit.HasValue);
+        var hasLocationLimits = ReuseLocationsFromId is null &&
+            Locations is not null && Locations.Any(l => l.Limit.HasValue);
 
-        if (calculateLimit && !hasLocationLimits)
+        if (ReuseLocationsFromId is null && calculateLimit && !hasLocationLimits)
         {
             limit = 0;
 
@@ -102,12 +107,17 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
             .WithType(Type)
             .WithTarget(Target);
 
+        if (ReuseLocationsFromId is not null)
+        {
+            builder.ReuseLocationsFromId(ReuseLocationsFromId);
+        }
+
         if (limit.HasValue)
         {
             builder.WithLimit(limit);
         }
 
-        if (SimpleLocations is not null)
+        if (ReuseLocationsFromId is null && SimpleLocations is not null)
         {
             foreach (var loc in SimpleLocations)
             {
@@ -122,7 +132,7 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
             }
         }
 
-        if (Locations is not null)
+        if (ReuseLocationsFromId is null && Locations is not null)
         {
             builder.WithLocations(Locations);
         }

--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public sealed class MeasurementRequestTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    static MeasurementRequestTests()
+    {
+        JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+    }
+
+    [Fact]
+    public void SerializesMeasurementIdForLocations()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .ReuseLocationsFromId("previous-id")
+            .Build();
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("locations", out var loc));
+        Assert.Equal(JsonValueKind.String, loc.ValueKind);
+        Assert.Equal("previous-id", loc.GetString());
+        Assert.False(root.TryGetProperty("reuseLocationsFromId", out _));
+        Assert.False(root.TryGetProperty("locations", out var _1) && _1.ValueKind == JsonValueKind.Array);
+    }
+
+    [Fact]
+    public void SerializesLocationArray()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .AddCountry("DE")
+            .AddCountry("US")
+            .Build();
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("locations", out var loc));
+        Assert.Equal(JsonValueKind.Array, loc.ValueKind);
+        Assert.Equal(2, loc.GetArrayLength());
+        Assert.False(root.TryGetProperty("reuseLocationsFromId", out _));
+    }
+
+    [Fact]
+    public void LocationsOverrideReuseId()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .ReuseLocationsFromId("old")
+            .AddCountry("DE")
+            .Build();
+
+        Assert.Null(request.ReuseLocationsFromId);
+        Assert.NotNull(request.Locations);
+    }
+
+    [Fact]
+    public void ReuseIdClearsLocations()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .AddCountry("DE")
+            .ReuseLocationsFromId("new")
+            .Build();
+
+        Assert.Equal("new", request.ReuseLocationsFromId);
+        Assert.Null(request.Locations);
+    }
+}

--- a/Globalping/MeasurementRequestBuilder.cs
+++ b/Globalping/MeasurementRequestBuilder.cs
@@ -18,6 +18,13 @@ public class MeasurementRequestBuilder
         return this;
     }
 
+    public MeasurementRequestBuilder ReuseLocationsFromId(string measurementId)
+    {
+        _request.ReuseLocationsFromId = measurementId;
+        _request.Locations = null;
+        return this;
+    }
+
     public MeasurementRequestBuilder AddCountry(string country, int? limit = null)
     {
         var loc = new LocationRequest { Country = country, Limit = limit };
@@ -75,12 +82,14 @@ public class MeasurementRequestBuilder
     public MeasurementRequestBuilder WithLocations(IEnumerable<LocationRequest> locations)
     {
         _request.Locations = new List<LocationRequest>(locations);
+        _request.ReuseLocationsFromId = null;
         return this;
     }
 
     public MeasurementRequestBuilder AddLocation(LocationRequest location)
     {
         _request.Locations ??= new List<LocationRequest>();
+        _request.ReuseLocationsFromId = null;
         _request.Locations.Add(location);
         return this;
     }

--- a/Globalping/Models/MeasurementRequest.cs
+++ b/Globalping/Models/MeasurementRequest.cs
@@ -13,8 +13,15 @@ public class MeasurementRequest {
     [JsonPropertyName("inProgressUpdates")]
     public bool InProgressUpdates { get; set; } = false;
 
-    [JsonPropertyName("locations")]
+    [JsonIgnore]
     public List<LocationRequest>? Locations { get; set; }
+
+    [JsonIgnore]
+    public string? ReuseLocationsFromId { get; set; }
+
+    [JsonPropertyName("locations")]
+    public object? SerializedLocations =>
+        (object?)ReuseLocationsFromId ?? Locations;
 
     [JsonPropertyName("limit")]
     public int? Limit { get; set; }


### PR DESCRIPTION
## Summary
- allow `MeasurementRequest` to specify a previous measurement ID instead of a list of `LocationRequest`
- propagate new `ReuseLocationsFromId` through the builder and PowerShell command
- show example usage in BuildRequestExample
- add tests for serialization and builder behavior

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --verbosity minimal`
- `pwsh -NoLogo -NoProfile Module/Globalping.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684dcc4ff448832e8d1d77b278fed142