### PR TITLE
Add typed enums for request options

### DIFF
--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -1,6 +1,6 @@
 using System;
 using Globalping;
-using System.Net;
+                    Method = HttpRequestMethod.GET,
 using System.Net.Http;
 using System.Threading.Tasks;
 

--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -1,25 +1,18 @@
 using System;
 using Globalping;
-namespace Globalping.Examples
-{
-}
 using System.Threading.Tasks;
 
 namespace Globalping.Examples;
 
-public static class ExecuteHttpExample
-{
-    public static async Task RunAsync()
-    {
+public static class ExecuteHttpExample {
+    public static async Task RunAsync() {
         var builder = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Http)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new HttpOptions
-            {
-                Request = new HttpRequestOptions
-                {
-                    Method = "GET",
+            .WithMeasurementOptions(new HttpOptions {
+                Request = new HttpRequestOptions {
+                    Method = HttpRequestMethod.GET,
                     Path = "/"
                 }
             });
@@ -27,9 +20,8 @@ public static class ExecuteHttpExample
         var request = builder.Build();
         request.InProgressUpdates = false;
 
-        using var httpClient = new HttpClient(new HttpClientHandler
-        {
-            AutomaticDecompression = DecompressionMethods.All
+        using var httpClient = new HttpClient(new HttpClientHandler {
+            AutomaticDecompression = System.Net.DecompressionMethods.All
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
@@ -42,14 +34,11 @@ public static class ExecuteHttpExample
 
         ConsoleHelpers.WriteJson(request, $"Request sent (HTTP ID: {measurementId})");
 
-        if (result != null)
-        {
+        if (result != null) {
             ConsoleHelpers.WriteJson(result, "Measurement result");
 
-            if (result.Results != null)
-            {
-                foreach (var item in result.Results)
-                {
+            if (result.Results != null) {
+                foreach (var item in result.Results) {
                     ConsoleHelpers.WriteTable(item.Probe, "Probe");
                     ConsoleHelpers.WriteTable(item.Data, "Result details");
                 }

--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -1,7 +1,8 @@
 using System;
 using Globalping;
-                    Method = HttpRequestMethod.GET,
-using System.Net.Http;
+namespace Globalping.Examples
+{
+}
 using System.Threading.Tasks;
 
 namespace Globalping.Examples;

--- a/Globalping/Enums/DnsProtocol.cs
+++ b/Globalping/Enums/DnsProtocol.cs
@@ -5,6 +5,6 @@ namespace Globalping;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DnsProtocol
 {
-    Tcp,
-    Udp
+    TCP,
+    UDP
 }

--- a/Globalping/Enums/DnsProtocol.cs
+++ b/Globalping/Enums/DnsProtocol.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DnsProtocol
+{
+    Tcp,
+    Udp
+}

--- a/Globalping/Enums/HttpProtocol.cs
+++ b/Globalping/Enums/HttpProtocol.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HttpProtocol
+{
+    Http,
+    Https,
+    Http2
+}

--- a/Globalping/Enums/HttpProtocol.cs
+++ b/Globalping/Enums/HttpProtocol.cs
@@ -5,7 +5,7 @@ namespace Globalping;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum HttpProtocol
 {
-    Http,
-    Https,
-    Http2
+    HTTP,
+    HTTPS,
+    HTTP2
 }

--- a/Globalping/Enums/HttpRequestMethod.cs
+++ b/Globalping/Enums/HttpRequestMethod.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HttpRequestMethod
+{
+    Head,
+    Get,
+    Options
+}

--- a/Globalping/Enums/HttpRequestMethod.cs
+++ b/Globalping/Enums/HttpRequestMethod.cs
@@ -5,7 +5,7 @@ namespace Globalping;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum HttpRequestMethod
 {
-    Head,
-    Get,
-    Options
+    HEAD,
+    GET,
+    OPTIONS
 }

--- a/Globalping/Enums/IpVersion.cs
+++ b/Globalping/Enums/IpVersion.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(IpVersionConverter))]
+public enum IpVersion
+{
+    Four = 4,
+    Six = 6
+}

--- a/Globalping/Enums/IpVersionConverter.cs
+++ b/Globalping/Enums/IpVersionConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+public sealed class IpVersionConverter : JsonConverter<IpVersion>
+{
+    public override IpVersion Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetInt32();
+        return value == 6 ? IpVersion.Six : IpVersion.Four;
+    }
+
+    public override void Write(Utf8JsonWriter writer, IpVersion value, JsonSerializerOptions options)
+    {
+        writer.WriteNumberValue((int)value);
+    }
+}

--- a/Globalping/Enums/MtrProtocol.cs
+++ b/Globalping/Enums/MtrProtocol.cs
@@ -5,7 +5,7 @@ namespace Globalping;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MtrProtocol
 {
-    Icmp,
-    Tcp,
-    Udp
+    ICMP,
+    TCP,
+    UDP
 }

--- a/Globalping/Enums/MtrProtocol.cs
+++ b/Globalping/Enums/MtrProtocol.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MtrProtocol
+{
+    Icmp,
+    Tcp,
+    Udp
+}

--- a/Globalping/Enums/TracerouteProtocol.cs
+++ b/Globalping/Enums/TracerouteProtocol.cs
@@ -5,7 +5,7 @@ namespace Globalping;
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TracerouteProtocol
 {
-    Icmp,
-    Tcp,
-    Udp
+    ICMP,
+    TCP,
+    UDP
 }

--- a/Globalping/Enums/TracerouteProtocol.cs
+++ b/Globalping/Enums/TracerouteProtocol.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TracerouteProtocol
+{
+    Icmp,
+    Tcp,
+    Udp
+}

--- a/Globalping/Models/DnsOptions.cs
+++ b/Globalping/Models/DnsOptions.cs
@@ -12,7 +12,7 @@ public class DnsOptions : IMeasurementOptions {
     public int Port { get; set; } = 53;
 
     [JsonPropertyName("protocol")]
-    public DnsProtocol Protocol { get; set; } = DnsProtocol.Udp;
+    public DnsProtocol Protocol { get; set; } = DnsProtocol.UDP;
 
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;

--- a/Globalping/Models/DnsOptions.cs
+++ b/Globalping/Models/DnsOptions.cs
@@ -12,10 +12,10 @@ public class DnsOptions : IMeasurementOptions {
     public int Port { get; set; } = 53;
 
     [JsonPropertyName("protocol")]
-    public string Protocol { get; set; } = "UDP";
+    public DnsProtocol Protocol { get; set; } = DnsProtocol.Udp;
 
     [JsonPropertyName("ipVersion")]
-    public int IpVersion { get; set; } = 4;
+    public IpVersion IpVersion { get; set; } = IpVersion.Four;
 
     [JsonPropertyName("trace")]
     public bool Trace { get; set; } = false;

--- a/Globalping/Models/HttpOptions.cs
+++ b/Globalping/Models/HttpOptions.cs
@@ -14,7 +14,7 @@ public class HttpOptions : IMeasurementOptions {
     public int Port { get; set; } = 80;
 
     [JsonPropertyName("protocol")]
-    public HttpProtocol Protocol { get; set; } = HttpProtocol.Https;
+    public HttpProtocol Protocol { get; set; } = HttpProtocol.HTTPS;
 
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;

--- a/Globalping/Models/HttpOptions.cs
+++ b/Globalping/Models/HttpOptions.cs
@@ -14,8 +14,8 @@ public class HttpOptions : IMeasurementOptions {
     public int Port { get; set; } = 80;
 
     [JsonPropertyName("protocol")]
-    public string Protocol { get; set; } = "HTTPS";
+    public HttpProtocol Protocol { get; set; } = HttpProtocol.Https;
 
     [JsonPropertyName("ipVersion")]
-    public int IpVersion { get; set; } = 4;
+    public IpVersion IpVersion { get; set; } = IpVersion.Four;
 }

--- a/Globalping/Models/HttpRequestOptions.cs
+++ b/Globalping/Models/HttpRequestOptions.cs
@@ -16,7 +16,7 @@ public class HttpRequestOptions
     public string? Query { get; set; }
 
     [JsonPropertyName("method")]
-    public string Method { get; set; } = "HEAD";
+    public HttpRequestMethod Method { get; set; } = HttpRequestMethod.Head;
 
     [JsonPropertyName("headers")]
     public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);

--- a/Globalping/Models/HttpRequestOptions.cs
+++ b/Globalping/Models/HttpRequestOptions.cs
@@ -16,7 +16,7 @@ public class HttpRequestOptions
     public string? Query { get; set; }
 
     [JsonPropertyName("method")]
-    public HttpRequestMethod Method { get; set; } = HttpRequestMethod.Head;
+    public HttpRequestMethod Method { get; set; } = HttpRequestMethod.HEAD;
 
     [JsonPropertyName("headers")]
     public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);

--- a/Globalping/Models/MtrOptions.cs
+++ b/Globalping/Models/MtrOptions.cs
@@ -7,10 +7,10 @@ public class MtrOptions : IMeasurementOptions
     public int Port { get; set; } = 80;
 
     [JsonPropertyName("protocol")]
-    public string Protocol { get; set; } = "ICMP";
+    public MtrProtocol Protocol { get; set; } = MtrProtocol.Icmp;
 
     [JsonPropertyName("ipVersion")]
-    public int IpVersion { get; set; } = 4;
+    public IpVersion IpVersion { get; set; } = IpVersion.Four;
 
     [JsonPropertyName("packets")]
     public int Packets { get; set; } = 3;

--- a/Globalping/Models/MtrOptions.cs
+++ b/Globalping/Models/MtrOptions.cs
@@ -7,7 +7,7 @@ public class MtrOptions : IMeasurementOptions
     public int Port { get; set; } = 80;
 
     [JsonPropertyName("protocol")]
-    public MtrProtocol Protocol { get; set; } = MtrProtocol.Icmp;
+    public MtrProtocol Protocol { get; set; } = MtrProtocol.ICMP;
 
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;

--- a/Globalping/Models/PingOptions.cs
+++ b/Globalping/Models/PingOptions.cs
@@ -6,6 +6,6 @@ public class PingOptions : IMeasurementOptions {
     public int Packets { get; set; } = 3;
 
     [JsonPropertyName("ipVersion")]
-    public int IpVersion { get; set; } = 4;
+    public IpVersion IpVersion { get; set; } = IpVersion.Four;
 }
 

--- a/Globalping/Models/TracerouteOptions.cs
+++ b/Globalping/Models/TracerouteOptions.cs
@@ -6,8 +6,8 @@ public class TracerouteOptions : IMeasurementOptions {
     public int Port { get; set; } = 80;
 
     [JsonPropertyName("protocol")]
-    public string Protocol { get; set; } = "ICMP";
+    public TracerouteProtocol Protocol { get; set; } = TracerouteProtocol.Icmp;
 
     [JsonPropertyName("ipVersion")]
-    public int IpVersion { get; set; } = 4;
+    public IpVersion IpVersion { get; set; } = IpVersion.Four;
 }

--- a/Globalping/Models/TracerouteOptions.cs
+++ b/Globalping/Models/TracerouteOptions.cs
@@ -6,7 +6,7 @@ public class TracerouteOptions : IMeasurementOptions {
     public int Port { get; set; } = 80;
 
     [JsonPropertyName("protocol")]
-    public TracerouteProtocol Protocol { get; set; } = TracerouteProtocol.Icmp;
+    public TracerouteProtocol Protocol { get; set; } = TracerouteProtocol.ICMP;
 
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;


### PR DESCRIPTION
## Summary
- add protocol enums and typed IP version
- switch option models to use enums instead of primitive types
- include converter so IP version serializes as a number

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command ./Module/Globalping.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684dd1f518b0832ebcb112c76df49b46