### PR TITLE
Fix warnings from nullable arguments

### DIFF
--- a/Globalping.Examples/Examples/ExecuteDnsExample.cs
+++ b/Globalping.Examples/Examples/ExecuteDnsExample.cs
@@ -37,14 +37,18 @@ public static class ExecuteDnsExample
         var result = await client.GetMeasurementByIdAsync(measurementId);
 
         ConsoleHelpers.WriteJson(request, $"Request sent (DNS ID: {measurementId})");
-        ConsoleHelpers.WriteJson(result, "Measurement result");
 
-        if (result.Results != null)
+        if (result != null)
         {
-            foreach (var item in result.Results)
+            ConsoleHelpers.WriteJson(result, "Measurement result");
+
+            if (result.Results != null)
             {
-                ConsoleHelpers.WriteTable(item.Probe, "Probe");
-                ConsoleHelpers.WriteTable(item.Data, "Result details");
+                foreach (var item in result.Results)
+                {
+                    ConsoleHelpers.WriteTable(item.Probe, "Probe");
+                    ConsoleHelpers.WriteTable(item.Data, "Result details");
+                }
             }
         }
     }

--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -40,14 +40,18 @@ public static class ExecuteHttpExample
         var result = await client.GetMeasurementByIdAsync(measurementId);
 
         ConsoleHelpers.WriteJson(request, $"Request sent (HTTP ID: {measurementId})");
-        ConsoleHelpers.WriteJson(result, "Measurement result");
 
-        if (result.Results != null)
+        if (result != null)
         {
-            foreach (var item in result.Results)
+            ConsoleHelpers.WriteJson(result, "Measurement result");
+
+            if (result.Results != null)
             {
-                ConsoleHelpers.WriteTable(item.Probe, "Probe");
-                ConsoleHelpers.WriteTable(item.Data, "Result details");
+                foreach (var item in result.Results)
+                {
+                    ConsoleHelpers.WriteTable(item.Probe, "Probe");
+                    ConsoleHelpers.WriteTable(item.Data, "Result details");
+                }
             }
         }
     }

--- a/Globalping.Examples/Examples/ExecuteMeasurementExample.cs
+++ b/Globalping.Examples/Examples/ExecuteMeasurementExample.cs
@@ -33,14 +33,18 @@ public static class ExecuteMeasurementExample
         var result = await client.GetMeasurementByIdAsync(measurementId);
 
         ConsoleHelpers.WriteJson(request, $"Request sent (Ping ID: {measurementId})");
-        ConsoleHelpers.WriteJson(result, "Measurement result");
 
-        if (result.Results != null)
+        if (result != null)
         {
-            foreach (var item in result.Results)
+            ConsoleHelpers.WriteJson(result, "Measurement result");
+
+            if (result.Results != null)
             {
-                ConsoleHelpers.WriteTable(item.Probe, "Probe");
-                ConsoleHelpers.WriteTable(item.Data, "Result details");
+                foreach (var item in result.Results)
+                {
+                    ConsoleHelpers.WriteTable(item.Probe, "Probe");
+                    ConsoleHelpers.WriteTable(item.Data, "Result details");
+                }
             }
         }
     }

--- a/Globalping.Examples/Examples/ExecuteMtrExample.cs
+++ b/Globalping.Examples/Examples/ExecuteMtrExample.cs
@@ -32,14 +32,18 @@ public static class ExecuteMtrExample
         var result = await client.GetMeasurementByIdAsync(measurementId);
 
         ConsoleHelpers.WriteJson(request, $"Request sent (MTR ID: {measurementId})");
-        ConsoleHelpers.WriteJson(result, "Measurement result");
 
-        if (result.Results != null)
+        if (result != null)
         {
-            foreach (var item in result.Results)
+            ConsoleHelpers.WriteJson(result, "Measurement result");
+
+            if (result.Results != null)
             {
-                ConsoleHelpers.WriteTable(item.Probe, "Probe");
-                ConsoleHelpers.WriteTable(item.Data, "Result details");
+                foreach (var item in result.Results)
+                {
+                    ConsoleHelpers.WriteTable(item.Probe, "Probe");
+                    ConsoleHelpers.WriteTable(item.Data, "Result details");
+                }
             }
         }
     }

--- a/Globalping.Examples/Examples/ExecuteTracerouteExample.cs
+++ b/Globalping.Examples/Examples/ExecuteTracerouteExample.cs
@@ -32,14 +32,18 @@ public static class ExecuteTracerouteExample
         var result = await client.GetMeasurementByIdAsync(measurementId);
 
         ConsoleHelpers.WriteJson(request, $"Request sent (Traceroute ID: {measurementId})");
-        ConsoleHelpers.WriteJson(result, "Measurement result");
 
-        if (result.Results != null)
+        if (result != null)
         {
-            foreach (var item in result.Results)
+            ConsoleHelpers.WriteJson(result, "Measurement result");
+
+            if (result.Results != null)
             {
-                ConsoleHelpers.WriteTable(item.Probe, "Probe");
-                ConsoleHelpers.WriteTable(item.Data, "Result details");
+                foreach (var item in result.Results)
+                {
+                    ConsoleHelpers.WriteTable(item.Probe, "Probe");
+                    ConsoleHelpers.WriteTable(item.Data, "Result details");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix possible null reference warnings in example apps

## Testing
- `dotnet restore Globalping.sln`
- `dotnet build Globalping.sln --configuration Release --no-restore`
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --configuration Release --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684dd7379514832e9b130fe2a34dbf11