### PR TITLE
Add Get-GlobalpingLimit cmdlet

### DIFF
--- a/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
@@ -1,0 +1,38 @@
+using System.Management.Automation;
+using System.Net;
+using System.Net.Http;
+
+namespace Globalping.PowerShell;
+
+/// <summary>Retrieve current API rate limits.</summary>
+/// <para>Calls the Globalping <c>/limits</c> endpoint and returns limit information.</para>
+/// <example>
+///   <summary>Check remaining requests</summary>
+///   <code>Get-GlobalpingLimit</code>
+///   <para>Returns rate limit information for the anonymous user or provided API key.</para>
+/// </example>
+[Cmdlet(VerbsCommon.Get, "GlobalpingLimit")]
+[OutputType(typeof(Limits))]
+public class GetGlobalpingLimitCommand : PSCmdlet
+{
+    /// <summary>API key used for authenticated calls.</summary>
+    [Parameter]
+    [Alias("Token")]
+    public string? ApiKey { get; set; }
+
+    /// <inheritdoc/>
+    protected override void ProcessRecord()
+    {
+        using var httpClient = new HttpClient(new HttpClientHandler
+        {
+#if NET6_0_OR_GREATER
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli
+#else
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+#endif
+        });
+        var service = new ProbeService(httpClient, ApiKey);
+        var limits = service.GetLimitsAsync().GetAwaiter().GetResult();
+        WriteObject(limits);
+    }
+}

--- a/Module/Examples/Example-Limits.ps1
+++ b/Module/Examples/Example-Limits.ps1
@@ -1,0 +1,3 @@
+Import-Module $PSScriptRoot\..\Globalping.psd1 -Force
+
+Get-GlobalpingLimit | Format-List

--- a/Module/Globalping.psd1
+++ b/Module/Globalping.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute')
+    CmdletsToExport      = @('Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute', 'Get-GlobalpingLimit')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
## Summary
- introduce `Get-GlobalpingLimit` cmdlet to expose API rate limits
- export the cmdlet from the module
- provide usage example

## Testing
- `dotnet test --no-build`
- `pwsh -c "./Module/Globalping.Tests.ps1"`

------
https://chatgpt.com/codex/tasks/task_e_684dde2667b8832ebb9f7cb80bc10dad