### PR TITLE
Fix rateLimit path for limits deserialization

### DIFF
--- a/Globalping.Tests/LimitsDeserializationTests.cs
+++ b/Globalping.Tests/LimitsDeserializationTests.cs
@@ -11,8 +11,8 @@ public sealed class LimitsDeserializationTests
         var json = """
         {
             "rateLimit": {
-                "measurement": {
-                    "ping": { "type": "ip", "limit": 10, "remaining": 8, "reset": 1000 }
+                "measurements": {
+                    "create": { "type": "ip", "limit": 10, "remaining": 8, "reset": 1000 }
                 }
             }
         }
@@ -20,13 +20,13 @@ public sealed class LimitsDeserializationTests
 
         var limits = JsonSerializer.Deserialize<Limits>(json);
         Assert.NotNull(limits);
-        Assert.True(limits!.RateLimit.ContainsKey("measurement"));
-        var measurement = limits.RateLimit["measurement"];
-        Assert.True(measurement.ContainsKey("ping"));
-        var ping = measurement["ping"];
-        Assert.Equal("ip", ping.Type);
-        Assert.Equal(10, ping.Limit);
-        Assert.Equal(8, ping.Remaining);
-        Assert.Equal(1000, ping.Reset);
+        Assert.True(limits!.RateLimit.ContainsKey("measurements"));
+        var measurements = limits.RateLimit["measurements"];
+        Assert.True(measurements.ContainsKey("create"));
+        var create = measurements["create"];
+        Assert.Equal("ip", create.Type);
+        Assert.Equal(10, create.Limit);
+        Assert.Equal(8, create.Remaining);
+        Assert.Equal(1000, create.Reset);
     }
 }

--- a/Globalping/Models/Limits.cs
+++ b/Globalping/Models/Limits.cs
@@ -10,6 +10,7 @@ public class Limits
 {
     /// <summary>
     /// Nested dictionary containing rate limits grouped by category and action.
+    /// Currently the API exposes limits under <c>rateLimit.measurements.create</c>.
     /// </summary>
     [JsonPropertyName("rateLimit")]
     public Dictionary<string, Dictionary<string, RateLimitDetails>> RateLimit { get; set; } = new();


### PR DESCRIPTION
## Summary
- adjust test to use `rateLimit.measurements.create`
- document new nested structure in `Limits`

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684de1b739d4832e98d77e742ee0d8bf