### PR TITLE
Add credits support to limits

### DIFF
--- a/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
@@ -13,6 +13,7 @@ namespace Globalping.PowerShell;
 /// </example>
 [Cmdlet(VerbsCommon.Get, "GlobalpingLimit")]
 [OutputType(typeof(Limits))]
+[OutputType(typeof(Credits))]
 public class GetGlobalpingLimitCommand : PSCmdlet
 {
     /// <summary>API key used for authenticated calls.</summary>
@@ -33,6 +34,10 @@ public class GetGlobalpingLimitCommand : PSCmdlet
         });
         var service = new ProbeService(httpClient, ApiKey);
         var limits = service.GetLimitsAsync().GetAwaiter().GetResult();
+        if (limits?.Credits is not null)
+        {
+            WriteObject(limits.Credits);
+        }
         WriteObject(limits);
     }
 }

--- a/Globalping.Tests/LimitsDeserializationTests.cs
+++ b/Globalping.Tests/LimitsDeserializationTests.cs
@@ -29,4 +29,20 @@ public sealed class LimitsDeserializationTests
         Assert.Equal(8, ping.Remaining);
         Assert.Equal(1000, ping.Reset);
     }
+
+    [Fact]
+    public void DeserializesCredits()
+    {
+        var json = """
+        {
+            "rateLimit": {},
+            "credits": { "remaining": 42 }
+        }
+        """;
+
+        var limits = JsonSerializer.Deserialize<Limits>(json);
+        Assert.NotNull(limits);
+        Assert.NotNull(limits!.Credits);
+        Assert.Equal(42, limits.Credits!.Remaining);
+    }
 }

--- a/Globalping/Models/Limits.cs
+++ b/Globalping/Models/Limits.cs
@@ -13,4 +13,22 @@ public class Limits
     /// </summary>
     [JsonPropertyName("rateLimit")]
     public Dictionary<string, Dictionary<string, RateLimitDetails>> RateLimit { get; set; } = new();
+
+    /// <summary>
+    /// Remaining credits for the authenticated user.
+    /// </summary>
+    [JsonPropertyName("credits")]
+    public Credits? Credits { get; set; }
+}
+
+/// <summary>
+/// Represents credit information returned by the API.
+/// </summary>
+public class Credits
+{
+    /// <summary>
+    /// Number of credits still available.
+    /// </summary>
+    [JsonPropertyName("remaining")]
+    public int Remaining { get; set; }
 }


### PR DESCRIPTION
## Summary
- include credits info returned by the API
- write credits in Get-GlobalpingLimit
- test credits deserialization

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684de1adbfd4832eb112dfc9c087042c