### PR TITLE
Limits fix

### DIFF
--- a/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
@@ -34,10 +34,6 @@ public class GetGlobalpingLimitCommand : PSCmdlet
         });
         var service = new ProbeService(httpClient, ApiKey);
         var limits = service.GetLimitsAsync().GetAwaiter().GetResult();
-        if (limits?.Credits is not null)
-        {
-            WriteObject(limits.Credits);
-        }
         WriteObject(limits);
     }
 }

--- a/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
@@ -14,18 +14,15 @@ namespace Globalping.PowerShell;
 [Cmdlet(VerbsCommon.Get, "GlobalpingLimit")]
 [OutputType(typeof(Limits))]
 [OutputType(typeof(Credits))]
-public class GetGlobalpingLimitCommand : PSCmdlet
-{
+public class GetGlobalpingLimitCommand : PSCmdlet {
     /// <summary>API key used for authenticated calls.</summary>
     [Parameter]
     [Alias("Token")]
     public string? ApiKey { get; set; }
 
     /// <inheritdoc/>
-    protected override void ProcessRecord()
-    {
-        using var httpClient = new HttpClient(new HttpClientHandler
-        {
+    protected override void ProcessRecord() {
+        using var httpClient = new HttpClient(new HttpClientHandler {
 #if NET6_0_OR_GREATER
             AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli
 #else


### PR DESCRIPTION
This pull request includes changes to the `Globalping.PowerShell/GetGlobalpingLimitCommand.cs` file, focusing on simplifying the code structure and improving the handling of API responses. The most important changes involve streamlining the `ProcessRecord` method and modifying the class definition format.

### Code simplification:

* [`Globalping.PowerShell/GetGlobalpingLimitCommand.cs`](diffhunk://#diff-286e8f2edbb9bd9f444905425ad61314dce7c58f67a240bfe5822ccc7c459ef1L37-L40): Simplified the `ProcessRecord` method by removing the conditional check for `limits?.Credits` and directly writing the `limits` object to the output. This reduces unnecessary complexity in handling API responses.

### Code formatting:

* [`Globalping.PowerShell/GetGlobalpingLimitCommand.cs`](diffhunk://#diff-286e8f2edbb9bd9f444905425ad61314dce7c58f67a240bfe5822ccc7c459ef1L17-R25): Changed the class definition format for `GetGlobalpingLimitCommand` to use a single-line style, improving readability and consistency with modern coding practices.