### PR TITLE
Update Loss property to double

### DIFF
--- a/Globalping/Responses/Stats.cs
+++ b/Globalping/Responses/Stats.cs
@@ -15,7 +15,7 @@ public class Stats {
     public int Total { get; set; }
 
     [JsonPropertyName("loss")]
-    public int Loss { get; set; }
+    public double Loss { get; set; }
 
     [JsonPropertyName("rcv")]
     public int Rcv { get; set; }


### PR DESCRIPTION
## Summary
- use `double` for `Stats.Loss`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684de5a116f4832e95a7220d8a4f938b