### PR TITLE
Add structured result parsing

### DIFF
--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ResultParsingTests
+{
+    [Fact]
+    public void ParsesTracerouteHopsFromJson()
+    {
+        var json = @"{
+            \"id\": \"1\",
+            \"type\": \"traceroute\",
+            \"status\": \"finished\",
+            \"target\": \"cdn.jsdelivr.net\",
+            \"probesCount\": 1,
+            \"results\": [
+                {
+                    \"probe\": {
+                        \"continent\": \"OC\",
+                        \"region\": \"ANZ\",
+                        \"country\": \"AU\",
+                        \"state\": null,
+                        \"city\": \"Sydney\",
+                        \"asn\": 1,
+                        \"longitude\": 0,
+                        \"latitude\": 0,
+                        \"network\": \"test\",
+                        \"tags\": [],
+                        \"resolvers\": []
+                    },
+                    \"result\": {
+                        \"status\": \"finished\",
+                        \"resolvedAddress\": \"104.16.85.20\",
+                        \"resolvedHostname\": \"104.16.85.20\",
+                        \"hops\": [
+                            { \"resolvedHostname\": \"172.68.208.3\", \"resolvedAddress\": \"172.68.208.3\", \"timings\": [ { \"rtt\": 1.0 }, { \"rtt\": 2.0 } ] },
+                            { \"resolvedHostname\": \"104.16.85.20\", \"resolvedAddress\": \"104.16.85.20\", \"timings\": [ { \"rtt\": 0.5 } ] }
+                        ]
+                    }
+                }
+            ]
+        }";
+
+        var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        Assert.NotNull(resp);
+        var hops = resp!.GetTracerouteHops();
+        Assert.Equal(2, hops.Count);
+        Assert.Equal(1, hops[0].Hop);
+        Assert.Equal("172.68.208.3", hops[0].Host);
+        Assert.Equal(1.0, hops[0].Time1);
+    }
+
+    [Fact]
+    public void ParsesDnsAnswersFromJson()
+    {
+        var json = @"{
+            \"id\": \"1\",
+            \"type\": \"dns\",
+            \"status\": \"finished\",
+            \"target\": \"example.com\",
+            \"probesCount\": 1,
+            \"results\": [
+                {
+                    \"probe\": {
+                        \"continent\": \"OC\",
+                        \"region\": \"ANZ\",
+                        \"country\": \"AU\",
+                        \"state\": null,
+                        \"city\": \"Melbourne\",
+                        \"asn\": 1,
+                        \"longitude\": 0,
+                        \"latitude\": 0,
+                        \"network\": \"test\",
+                        \"tags\": [],
+                        \"resolvers\": []
+                    },
+                    \"result\": {
+                        \"status\": \"finished\",
+                        \"answers\": [
+                            { \"name\": \"example.com\", \"type\": \"A\", \"ttl\": 60, \"class\": \"IN\", \"value\": \"1.1.1.1\" }
+                        ]
+                    }
+                }
+            ]
+        }";
+
+        var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        Assert.NotNull(resp);
+        var records = resp!.GetDnsRecords();
+        Assert.Single(records);
+        Assert.Equal("example.com", records[0].Name);
+        Assert.Equal("A", records[0].Type);
+    }
+
+    [Fact]
+    public void ParsesHttpResponseFromJson()
+    {
+        var json = @"{
+            \"id\": \"1\",
+            \"type\": \"http\",
+            \"status\": \"finished\",
+            \"target\": \"https://example.com\",
+            \"probesCount\": 1,
+            \"results\": [
+                {
+                    \"probe\": {
+                        \"continent\": \"EU\",
+                        \"region\": \"EU\",
+                        \"country\": \"DE\",
+                        \"state\": null,
+                        \"city\": \"Berlin\",
+                        \"asn\": 1,
+                        \"longitude\": 0,
+                        \"latitude\": 0,
+                        \"network\": \"test\",
+                        \"tags\": [],
+                        \"resolvers\": []
+                    },
+                    \"result\": {
+                        \"status\": \"finished\",
+                        \"rawHeaders\": \"HTTP/1.1 200 OK\\nContent-Type: text/plain\\n\",
+                        \"rawBody\": \"hello\",
+                        \"truncated\": false,
+                        \"headers\": { \"content-type\": \"text/plain\" },
+                        \"statusCode\": 200,
+                        \"statusCodeName\": \"OK\"
+                    }
+                }
+            ]
+        }";
+
+        var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        Assert.NotNull(resp);
+        var http = resp!.GetHttpResponses();
+        Assert.Single(http);
+        Assert.Equal(200, http[0].StatusCode);
+        Assert.Equal("hello", http[0].Body);
+    }
+}

--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -8,39 +8,41 @@ public class ResultParsingTests
     [Fact]
     public void ParsesTracerouteHopsFromJson()
     {
-        var json = @"{
-            \"id\": \"1\",
-            \"type\": \"traceroute\",
-            \"status\": \"finished\",
-            \"target\": \"cdn.jsdelivr.net\",
-            \"probesCount\": 1,
-            \"results\": [
-                {
-                    \"probe\": {
-                        \"continent\": \"OC\",
-                        \"region\": \"ANZ\",
-                        \"country\": \"AU\",
-                        \"state\": null,
-                        \"city\": \"Sydney\",
-                        \"asn\": 1,
-                        \"longitude\": 0,
-                        \"latitude\": 0,
-                        \"network\": \"test\",
-                        \"tags\": [],
-                        \"resolvers\": []
-                    },
-                    \"result\": {
-                        \"status\": \"finished\",
-                        \"resolvedAddress\": \"104.16.85.20\",
-                        \"resolvedHostname\": \"104.16.85.20\",
-                        \"hops\": [
-                            { \"resolvedHostname\": \"172.68.208.3\", \"resolvedAddress\": \"172.68.208.3\", \"timings\": [ { \"rtt\": 1.0 }, { \"rtt\": 2.0 } ] },
-                            { \"resolvedHostname\": \"104.16.85.20\", \"resolvedAddress\": \"104.16.85.20\", \"timings\": [ { \"rtt\": 0.5 } ] }
-                        ]
+        var json = """
+            {
+                "id": "1",
+                "type": "traceroute",
+                "status": "finished",
+                "target": "cdn.jsdelivr.net",
+                "probesCount": 1,
+                "results": [
+                    {
+                        "probe": {
+                            "continent": "OC",
+                            "region": "ANZ",
+                            "country": "AU",
+                            "state": null,
+                            "city": "Sydney",
+                            "asn": 1,
+                            "longitude": 0,
+                            "latitude": 0,
+                            "network": "test",
+                            "tags": [],
+                            "resolvers": []
+                        },
+                        "result": {
+                            "status": "finished",
+                            "resolvedAddress": "104.16.85.20",
+                            "resolvedHostname": "104.16.85.20",
+                            "hops": [
+                                { "resolvedHostname": "172.68.208.3", "resolvedAddress": "172.68.208.3", "timings": [ { "rtt": 1.0 }, { "rtt": 2.0 } ] },
+                                { "resolvedHostname": "104.16.85.20", "resolvedAddress": "104.16.85.20", "timings": [ { "rtt": 0.5 } ] }
+                            ]
+                        }
                     }
-                }
-            ]
-        }";
+                ]
+            }
+            """;
 
         var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
         Assert.NotNull(resp);
@@ -54,36 +56,38 @@ public class ResultParsingTests
     [Fact]
     public void ParsesDnsAnswersFromJson()
     {
-        var json = @"{
-            \"id\": \"1\",
-            \"type\": \"dns\",
-            \"status\": \"finished\",
-            \"target\": \"example.com\",
-            \"probesCount\": 1,
-            \"results\": [
-                {
-                    \"probe\": {
-                        \"continent\": \"OC\",
-                        \"region\": \"ANZ\",
-                        \"country\": \"AU\",
-                        \"state\": null,
-                        \"city\": \"Melbourne\",
-                        \"asn\": 1,
-                        \"longitude\": 0,
-                        \"latitude\": 0,
-                        \"network\": \"test\",
-                        \"tags\": [],
-                        \"resolvers\": []
-                    },
-                    \"result\": {
-                        \"status\": \"finished\",
-                        \"answers\": [
-                            { \"name\": \"example.com\", \"type\": \"A\", \"ttl\": 60, \"class\": \"IN\", \"value\": \"1.1.1.1\" }
-                        ]
+        var json = """
+            {
+                "id": "1",
+                "type": "dns",
+                "status": "finished",
+                "target": "example.com",
+                "probesCount": 1,
+                "results": [
+                    {
+                        "probe": {
+                            "continent": "OC",
+                            "region": "ANZ",
+                            "country": "AU",
+                            "state": null,
+                            "city": "Melbourne",
+                            "asn": 1,
+                            "longitude": 0,
+                            "latitude": 0,
+                            "network": "test",
+                            "tags": [],
+                            "resolvers": []
+                        },
+                        "result": {
+                            "status": "finished",
+                            "answers": [
+                                { "name": "example.com", "type": "A", "ttl": 60, "class": "IN", "value": "1.1.1.1" }
+                            ]
+                        }
                     }
-                }
-            ]
-        }";
+                ]
+            }
+            """;
 
         var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
         Assert.NotNull(resp);
@@ -96,39 +100,41 @@ public class ResultParsingTests
     [Fact]
     public void ParsesHttpResponseFromJson()
     {
-        var json = @"{
-            \"id\": \"1\",
-            \"type\": \"http\",
-            \"status\": \"finished\",
-            \"target\": \"https://example.com\",
-            \"probesCount\": 1,
-            \"results\": [
-                {
-                    \"probe\": {
-                        \"continent\": \"EU\",
-                        \"region\": \"EU\",
-                        \"country\": \"DE\",
-                        \"state\": null,
-                        \"city\": \"Berlin\",
-                        \"asn\": 1,
-                        \"longitude\": 0,
-                        \"latitude\": 0,
-                        \"network\": \"test\",
-                        \"tags\": [],
-                        \"resolvers\": []
-                    },
-                    \"result\": {
-                        \"status\": \"finished\",
-                        \"rawHeaders\": \"HTTP/1.1 200 OK\\nContent-Type: text/plain\\n\",
-                        \"rawBody\": \"hello\",
-                        \"truncated\": false,
-                        \"headers\": { \"content-type\": \"text/plain\" },
-                        \"statusCode\": 200,
-                        \"statusCodeName\": \"OK\"
+        var json = """
+            {
+                "id": "1",
+                "type": "http",
+                "status": "finished",
+                "target": "https://example.com",
+                "probesCount": 1,
+                "results": [
+                    {
+                        "probe": {
+                            "continent": "EU",
+                            "region": "EU",
+                            "country": "DE",
+                            "state": null,
+                            "city": "Berlin",
+                            "asn": 1,
+                            "longitude": 0,
+                            "latitude": 0,
+                            "network": "test",
+                            "tags": [],
+                            "resolvers": []
+                        },
+                        "result": {
+                            "status": "finished",
+                            "rawHeaders": "HTTP/1.1 200 OK\nContent-Type: text/plain\n",
+                            "rawBody": "hello",
+                            "truncated": false,
+                            "headers": { "content-type": "text/plain" },
+                            "statusCode": 200,
+                            "statusCodeName": "OK"
+                        }
                     }
-                }
-            ]
-        }";
+                ]
+            }
+            """;
 
         var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
         Assert.NotNull(resp);

--- a/Globalping/Responses/DnsAnswer.cs
+++ b/Globalping/Responses/DnsAnswer.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+namespace Globalping;
+public class DnsAnswer
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("ttl")]
+    public int Ttl { get; set; }
+
+    [JsonPropertyName("class")]
+    public string Class { get; set; } = string.Empty;
+
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = string.Empty;
+}

--- a/Globalping/Responses/DnsTimings.cs
+++ b/Globalping/Responses/DnsTimings.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+namespace Globalping;
+public class DnsTimings
+{
+    [JsonPropertyName("total")]
+    public double Total { get; set; }
+}

--- a/Globalping/Responses/HttpTimings.cs
+++ b/Globalping/Responses/HttpTimings.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+namespace Globalping;
+public class HttpTimings
+{
+    [JsonPropertyName("total")]
+    public int? Total { get; set; }
+
+    [JsonPropertyName("dns")]
+    public int? Dns { get; set; }
+
+    [JsonPropertyName("tcp")]
+    public int? Tcp { get; set; }
+
+    [JsonPropertyName("tls")]
+    public int? Tls { get; set; }
+
+    [JsonPropertyName("firstByte")]
+    public int? FirstByte { get; set; }
+
+    [JsonPropertyName("download")]
+    public int? Download { get; set; }
+}

--- a/Globalping/Responses/ResultDetails.cs
+++ b/Globalping/Responses/ResultDetails.cs
@@ -22,5 +22,35 @@ public class ResultDetails {
 
     [JsonPropertyName("stats")]
     public Stats? Stats { get; set; }
+
+    [JsonPropertyName("hops")]
+    public JsonElement? Hops { get; set; }
+
+    [JsonPropertyName("answers")]
+    public List<DnsAnswer>? Answers { get; set; }
+
+    [JsonPropertyName("resolver")]
+    public string? Resolver { get; set; }
+
+    [JsonPropertyName("tls")]
+    public TlsCertificate? Tls { get; set; }
+
+    [JsonPropertyName("rawHeaders")]
+    public string? RawHeaders { get; set; }
+
+    [JsonPropertyName("headers")]
+    public Dictionary<string, JsonElement>? Headers { get; set; }
+
+    [JsonPropertyName("rawBody")]
+    public string? RawBody { get; set; }
+
+    [JsonPropertyName("truncated")]
+    public bool? Truncated { get; set; }
+
+    [JsonPropertyName("statusCode")]
+    public int? StatusCode { get; set; }
+
+    [JsonPropertyName("statusCodeName")]
+    public string? StatusCodeName { get; set; }
 }
 

--- a/Globalping/Responses/Stats.cs
+++ b/Globalping/Responses/Stats.cs
@@ -22,5 +22,17 @@ public class Stats {
 
     [JsonPropertyName("drop")]
     public int Drop { get; set; }
+
+    [JsonPropertyName("stDev")]
+    public double? StDev { get; set; }
+
+    [JsonPropertyName("jMin")]
+    public double? JMin { get; set; }
+
+    [JsonPropertyName("jAvg")]
+    public double? JAvg { get; set; }
+
+    [JsonPropertyName("jMax")]
+    public double? JMax { get; set; }
 }
 

--- a/Globalping/Responses/Timing.cs
+++ b/Globalping/Responses/Timing.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace Globalping;
 public class Timing {
     [JsonPropertyName("ttl")]
-    public int Ttl { get; set; }
+    public int? Ttl { get; set; }
 
     [JsonPropertyName("rtt")]
     public double Rtt { get; set; }

--- a/Globalping/Responses/TlsCertificate.cs
+++ b/Globalping/Responses/TlsCertificate.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Text.Json.Serialization;
+namespace Globalping;
+public class TlsCertificate
+{
+    [JsonPropertyName("protocol")]
+    public string Protocol { get; set; } = string.Empty;
+
+    [JsonPropertyName("cipherName")]
+    public string CipherName { get; set; } = string.Empty;
+
+    [JsonPropertyName("authorized")]
+    public bool Authorized { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("expiresAt")]
+    public DateTime ExpiresAt { get; set; }
+
+    [JsonPropertyName("subject")]
+    public TlsCertificateSubject Subject { get; set; } = new();
+
+    [JsonPropertyName("issuer")]
+    public TlsCertificateIssuer Issuer { get; set; } = new();
+
+    [JsonPropertyName("keyType")]
+    public string? KeyType { get; set; }
+
+    [JsonPropertyName("keyBits")]
+    public double? KeyBits { get; set; }
+
+    [JsonPropertyName("serialNumber")]
+    public string SerialNumber { get; set; } = string.Empty;
+
+    [JsonPropertyName("fingerprint256")]
+    public string Fingerprint256 { get; set; } = string.Empty;
+
+    [JsonPropertyName("publicKey")]
+    public string? PublicKey { get; set; }
+}

--- a/Globalping/Responses/TlsCertificateIssuer.cs
+++ b/Globalping/Responses/TlsCertificateIssuer.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+namespace Globalping;
+public class TlsCertificateIssuer
+{
+    [JsonPropertyName("C")]
+    public string? C { get; set; }
+
+    [JsonPropertyName("O")]
+    public string? O { get; set; }
+
+    [JsonPropertyName("CN")]
+    public string? CN { get; set; }
+}

--- a/Globalping/Responses/TlsCertificateSubject.cs
+++ b/Globalping/Responses/TlsCertificateSubject.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+namespace Globalping;
+public class TlsCertificateSubject
+{
+    [JsonPropertyName("CN")]
+    public string? CN { get; set; }
+
+    [JsonPropertyName("alt")]
+    public string? Alt { get; set; }
+}

--- a/Globalping/ResultExtensions.cs
+++ b/Globalping/ResultExtensions.cs
@@ -36,7 +36,7 @@ public static class ResultExtensions
 
     public static List<TracerouteHopResult> ToTracerouteHops(this Result result, string target)
     {
-        return MeasurementResponseExtensions.ParseTraceroute(result.Data?.RawOutput).Select(h =>
+        return MeasurementResponseExtensions.ParseTraceroute(result.Data).Select(h =>
         {
             h.Target = target;
             h.Country = result.Probe.Country;
@@ -54,7 +54,7 @@ public static class ResultExtensions
 
     public static List<MtrHopResult> ToMtrHops(this Result result, string target)
     {
-        return MeasurementResponseExtensions.ParseMtr(result.Data?.RawOutput).Select(h =>
+        return MeasurementResponseExtensions.ParseMtr(result.Data).Select(h =>
         {
             h.Target = target;
             h.Country = result.Probe.Country;
@@ -72,7 +72,7 @@ public static class ResultExtensions
 
     public static List<DnsRecordResult> ToDnsRecords(this Result result, string target)
     {
-        return MeasurementResponseExtensions.ParseDns(result.Data?.RawOutput).Select(h =>
+        return MeasurementResponseExtensions.ParseDns(result.Data).Select(h =>
         {
             h.Target = target;
             h.Country = result.Probe.Country;
@@ -88,7 +88,7 @@ public static class ResultExtensions
 
     public static HttpResponseResult? ToHttpResponse(this Result result, string target)
     {
-        var resp = MeasurementResponseExtensions.ParseHttp(result.Data?.RawOutput).FirstOrDefault();
+        var resp = MeasurementResponseExtensions.ParseHttp(result.Data).FirstOrDefault();
         if (resp is null)
         {
             return null;


### PR DESCRIPTION
## Summary
- support structured fields for measurement results
- parse traceroute, mtr, DNS and HTTP results from JSON fields
- extend `Stats` and `Timing` models
- add TLS and answer models
- test deserialization of new result structures

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684de64b0130832e985bc5294aadd10e