### PR TITLE
Add TlsKeyType enum and update TLS certificate parsing

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -31,4 +31,32 @@ public sealed class MeasurementResponseDeserializationTests
         Assert.Equal(1, response.Locations![0].Limit);
         Assert.Equal(1, response.Limit);
     }
+
+    [Fact]
+    public void DeserializesTlsKeyType()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "http",
+            "status": "finished",
+            "target": "https://example.com",
+            "probesCount": 1,
+            "results": [
+                {
+                    "result": {
+                        "tls": { "keyType": "RSA" }
+                    }
+                }
+            ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        Assert.NotNull(response);
+        Assert.NotNull(response!.Results);
+        Assert.Single(response.Results!);
+        Assert.NotNull(response.Results![0].Data.Tls);
+        Assert.Equal(TlsKeyType.RSA, response.Results![0].Data.Tls!.KeyType);
+    }
 }

--- a/Globalping/Enums/TlsKeyType.cs
+++ b/Globalping/Enums/TlsKeyType.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TlsKeyType
+{
+    RSA,
+    EC
+}

--- a/Globalping/Responses/TlsCertificate.cs
+++ b/Globalping/Responses/TlsCertificate.cs
@@ -28,7 +28,7 @@ public class TlsCertificate
     public TlsCertificateIssuer Issuer { get; set; } = new();
 
     [JsonPropertyName("keyType")]
-    public string? KeyType { get; set; }
+    public TlsKeyType? KeyType { get; set; }
 
     [JsonPropertyName("keyBits")]
     public double? KeyBits { get; set; }


### PR DESCRIPTION
## Summary
- introduce `TlsKeyType` enum with JsonStringEnumConverter
- use `TlsKeyType?` for `TlsCertificate.KeyType`
- test TLS key type deserialization

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684e890a6bf4832eac4cfd51a7074978