### PR TITLE
Add MeasurementStatus enum

### DIFF
--- a/Globalping/Enums/MeasurementStatus.cs
+++ b/Globalping/Enums/MeasurementStatus.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MeasurementStatus
+{
+    InProgress,
+    Finished
+}

--- a/Globalping/MeasurementClient.cs
+++ b/Globalping/MeasurementClient.cs
@@ -31,6 +31,7 @@ public class MeasurementClient {
     public MeasurementClient(HttpClient httpClient, string? apiKey = null) {
         _httpClient = httpClient;
         _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        _jsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
 
         if (!_httpClient.DefaultRequestHeaders.UserAgent.Any()) {
             _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Globalping.Net/1.0 (+https://github.com/EvotecIT/Globalping)");
@@ -109,10 +110,10 @@ public class MeasurementClient {
                 }
             }
 
-            if (measurementResponse?.Status == "in-progress") {
+            if (measurementResponse?.Status == MeasurementStatus.InProgress) {
                 await Task.Delay(500).ConfigureAwait(false);
             }
-        } while (measurementResponse != null && measurementResponse.Status == "in-progress");
+        } while (measurementResponse != null && measurementResponse.Status == MeasurementStatus.InProgress);
 
         return measurementResponse;
     }

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -30,6 +30,7 @@ public class ProbeService {
     {
         _httpClient = httpClient;
         _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        _jsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
 
         if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())
         {

--- a/Globalping/Responses/MeasurementResponse.cs
+++ b/Globalping/Responses/MeasurementResponse.cs
@@ -12,7 +12,7 @@ public class MeasurementResponse {
     public string? Type { get; set; }
 
     [JsonPropertyName("status")]
-    public string? Status { get; set; }
+    public MeasurementStatus Status { get; set; }
 
     [JsonPropertyName("createdAt")]
     public DateTime CreatedAt { get; set; }


### PR DESCRIPTION
## Summary
- add `MeasurementStatus` enum and use it in `MeasurementResponse`
- register kebab-case enum converter
- update polling logic to compare enum values

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684e8904125c832e81ec47e286fdcac8