### PR TITLE
Improve MeasurementResponse deserialization

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -59,4 +59,105 @@ public sealed class MeasurementResponseDeserializationTests
         Assert.NotNull(response.Results![0].Data.Tls);
         Assert.Equal(TlsKeyType.RSA, response.Results![0].Data.Tls!.KeyType);
     }
+
+    [Fact]
+    public void MapsPingOptions()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "ping",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "measurementOptions": { "packets": 5, "ipVersion": 6 }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        var opts = Assert.IsType<PingOptions>(response!.MeasurementOptions);
+        Assert.Equal(5, opts.Packets);
+        Assert.Equal(IpVersion.Six, opts.IpVersion);
+    }
+
+    [Fact]
+    public void MapsTracerouteOptions()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "traceroute",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "measurementOptions": { "port": 443, "protocol": "tcp", "ipVersion": 6 }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        var opts = Assert.IsType<TracerouteOptions>(response!.MeasurementOptions);
+        Assert.Equal(443, opts.Port);
+        Assert.Equal(TracerouteProtocol.TCP, opts.Protocol);
+        Assert.Equal(IpVersion.Six, opts.IpVersion);
+    }
+
+    [Fact]
+    public void MapsDnsOptions()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "dns",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "measurementOptions": { "protocol": "udp", "trace": true }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        var opts = Assert.IsType<DnsOptions>(response!.MeasurementOptions);
+        Assert.Equal(DnsProtocol.UDP, opts.Protocol);
+        Assert.True(opts.Trace);
+    }
+
+    [Fact]
+    public void MapsMtrOptions()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "mtr",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "measurementOptions": { "packets": 4, "protocol": "udp" }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        var opts = Assert.IsType<MtrOptions>(response!.MeasurementOptions);
+        Assert.Equal(4, opts.Packets);
+        Assert.Equal(MtrProtocol.UDP, opts.Protocol);
+    }
+
+    [Fact]
+    public void MapsHttpOptions()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "http",
+            "status": "finished",
+            "target": "https://example.com",
+            "probesCount": 1,
+            "measurementOptions": { "port": 8080, "protocol": "http" }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        var opts = Assert.IsType<HttpOptions>(response!.MeasurementOptions);
+        Assert.Equal(8080, opts.Port);
+        Assert.Equal(HttpProtocol.HTTP, opts.Protocol);
+    }
 }

--- a/Globalping/Responses/MeasurementResponse.cs
+++ b/Globalping/Responses/MeasurementResponse.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+[JsonConverter(typeof(MeasurementResponseConverter))]
 public class MeasurementResponse {
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
@@ -27,7 +28,7 @@ public class MeasurementResponse {
     public int ProbesCount { get; set; }
 
     [JsonPropertyName("measurementOptions")]
-    public MeasurementOptions? MeasurementOptions { get; set; }
+    public IMeasurementOptions? MeasurementOptions { get; set; }
 
     [JsonPropertyName("locations")]
     public List<LocationRequest>? Locations { get; set; }

--- a/Globalping/Responses/MeasurementResponseConverter.cs
+++ b/Globalping/Responses/MeasurementResponseConverter.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+internal sealed class MeasurementResponseConverter : JsonConverter<MeasurementResponse>
+{
+    private class RawResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("status")]
+        public MeasurementStatus Status { get; set; }
+
+        [JsonPropertyName("createdAt")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonPropertyName("updatedAt")]
+        public DateTime UpdatedAt { get; set; }
+
+        [JsonPropertyName("target")]
+        public string Target { get; set; } = string.Empty;
+
+        [JsonPropertyName("probesCount")]
+        public int ProbesCount { get; set; }
+
+        [JsonPropertyName("measurementOptions")]
+        public JsonElement? MeasurementOptions { get; set; }
+
+        [JsonPropertyName("locations")]
+        public List<LocationRequest>? Locations { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("results")]
+        public List<Result>? Results { get; set; }
+    }
+
+    public override MeasurementResponse? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var raw = JsonSerializer.Deserialize<RawResponse>(ref reader, options);
+        if (raw == null)
+        {
+            return null;
+        }
+
+        var response = new MeasurementResponse
+        {
+            Id = raw.Id,
+            Type = raw.Type,
+            Status = raw.Status,
+            CreatedAt = raw.CreatedAt,
+            UpdatedAt = raw.UpdatedAt,
+            Target = raw.Target,
+            ProbesCount = raw.ProbesCount,
+            Locations = raw.Locations,
+            Limit = raw.Limit,
+            Results = raw.Results
+        };
+
+        if (raw.MeasurementOptions.HasValue)
+        {
+            var elem = raw.MeasurementOptions.Value;
+            var type = raw.Type?.ToLowerInvariant();
+            response.MeasurementOptions = type switch
+            {
+                "ping" => elem.Deserialize<PingOptions>(options),
+                "traceroute" => elem.Deserialize<TracerouteOptions>(options),
+                "dns" => elem.Deserialize<DnsOptions>(options),
+                "mtr" => elem.Deserialize<MtrOptions>(options),
+                "http" => elem.Deserialize<HttpOptions>(options),
+                _ => null
+            };
+        }
+
+        return response;
+    }
+
+    public override void Write(Utf8JsonWriter writer, MeasurementResponse value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("id", value.Id);
+        if (value.Type != null)
+        {
+            writer.WriteString("type", value.Type);
+        }
+
+        writer.WritePropertyName("status");
+        JsonSerializer.Serialize(writer, value.Status, options);
+        writer.WriteString("createdAt", value.CreatedAt);
+        writer.WriteString("updatedAt", value.UpdatedAt);
+        writer.WriteString("target", value.Target);
+        writer.WriteNumber("probesCount", value.ProbesCount);
+
+        if (value.MeasurementOptions != null)
+        {
+            writer.WritePropertyName("measurementOptions");
+            JsonSerializer.Serialize(writer, value.MeasurementOptions, value.MeasurementOptions.GetType(), options);
+        }
+
+        if (value.Locations != null)
+        {
+            writer.WritePropertyName("locations");
+            JsonSerializer.Serialize(writer, value.Locations, options);
+        }
+        if (value.Limit.HasValue)
+        {
+            writer.WriteNumber("limit", value.Limit.Value);
+        }
+        if (value.Results != null)
+        {
+            writer.WritePropertyName("results");
+            JsonSerializer.Serialize(writer, value.Results, options);
+        }
+
+        writer.WriteEndObject();
+    }
+}


### PR DESCRIPTION
## Summary
- deserialize MeasurementResponse.MeasurementOptions to the correct option class
- implement MeasurementResponseConverter
- test all MeasurementOptions mappings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684e8decc33c832e9cc05bb3cf50ad8e