### PR TITLE
Implement WithInProgressUpdates builder

### DIFF
--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -84,4 +84,21 @@ public sealed class MeasurementRequestTests
         Assert.Equal("new", request.ReuseLocationsFromId);
         Assert.Null(request.Locations);
     }
+
+    [Fact]
+    public void SerializesInProgressUpdates()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .WithInProgressUpdates()
+            .Build();
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("inProgressUpdates", out var prop));
+        Assert.True(prop.GetBoolean());
+    }
 }

--- a/Globalping/MeasurementRequestBuilder.cs
+++ b/Globalping/MeasurementRequestBuilder.cs
@@ -103,6 +103,12 @@ public class MeasurementRequestBuilder
         return this;
     }
 
+    public MeasurementRequestBuilder WithInProgressUpdates(bool value = true)
+    {
+        _request.InProgressUpdates = value;
+        return this;
+    }
+
     public MeasurementRequestBuilder WithLimit(int? limit)
     {
         _request.Limit = limit;


### PR DESCRIPTION
## Summary
- add `WithInProgressUpdates` to `MeasurementRequestBuilder`
- test that the property serializes correctly

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684e9164a19c832e88c00686d3fd602b