### PR TITLE
Support multi-value HTTP headers

### DIFF
--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -142,5 +142,8 @@ public class ResultParsingTests
         Assert.Single(http);
         Assert.Equal(200, http[0].StatusCode);
         Assert.Equal("hello", http[0].Body);
+        Assert.True(http[0].Headers.ContainsKey("content-type"));
+        Assert.Single(http[0].Headers["content-type"]);
+        Assert.Equal("text/plain", http[0].Headers["content-type"][0]);
     }
 }

--- a/Globalping/HttpResponseResult.cs
+++ b/Globalping/HttpResponseResult.cs
@@ -8,7 +8,7 @@ public class HttpResponseResult
     public string Protocol { get; set; } = string.Empty;
     public int StatusCode { get; set; }
     public string StatusDescription { get; set; } = string.Empty;
-    public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+    public Dictionary<string, List<string>> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     public string? Body { get; set; }
     public string Country { get; set; } = string.Empty;
     public string City { get; set; } = string.Empty;

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -528,11 +528,13 @@ public static class MeasurementResponseExtensions {
                 {
                     if (kv.Value.ValueKind == JsonValueKind.Array)
                     {
-                        resp.Headers[kv.Key] = string.Join(",", kv.Value.EnumerateArray().Select(e => e.GetString()));
+                        resp.Headers[kv.Key] = kv.Value.EnumerateArray()
+                            .Select(e => e.GetString() ?? string.Empty)
+                            .ToList();
                     }
                     else
                     {
-                        resp.Headers[kv.Key] = kv.Value.GetString() ?? string.Empty;
+                        resp.Headers[kv.Key] = new List<string> { kv.Value.GetString() ?? string.Empty };
                     }
                 }
             }
@@ -569,7 +571,12 @@ public static class MeasurementResponseExtensions {
             if (sep > 0) {
                 var key = line.Substring(0, sep).Trim();
                 var value = line.Substring(sep + 1).Trim();
-                result.Headers[key] = value;
+                if (!result.Headers.TryGetValue(key, out var list))
+                {
+                    list = new List<string>();
+                    result.Headers[key] = list;
+                }
+                list.Add(value);
             }
         }
 

--- a/Module/Examples/Example-HTTP.ps1
+++ b/Module/Examples/Example-HTTP.ps1
@@ -3,8 +3,8 @@
 $Output = Start-GlobalpingHttp -Target "evotec.xyz" -Verbose -SimpleLocations "Krakow+PL"
 $Output | Format-Table
 $Output.Headers | Format-Table
-$Output.Headers['expires']
-$Output.Headers['cache-control']
+$Output.Headers['expires'][0]
+$Output.Headers['cache-control'][0]
 
 Start-GlobalpingHttp -Target "evotec.xyz" -Verbose -Classic | Format-Table
 


### PR DESCRIPTION
## Summary
- store HTTP headers as list values
- parse structured HTTP headers without joining
- adjust example and unit test

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_684e915ee0a8832e90dcb7646ac22963