### PR TITLE
Update MTR hop ASN parsing

### DIFF
--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json;
 using Xunit;
 
@@ -142,5 +143,50 @@ public class ResultParsingTests
         Assert.Single(http);
         Assert.Equal(200, http[0].StatusCode);
         Assert.Equal("hello", http[0].Body);
+    }
+
+    [Fact]
+    public void ParsesMtrAsnListFromJson()
+    {
+        var json = """
+            {
+                "id": "1",
+                "type": "mtr",
+                "status": "finished",
+                "target": "example.com",
+                "probesCount": 1,
+                "results": [
+                    {
+                        "probe": {
+                            "continent": "EU",
+                            "region": "EU",
+                            "country": "DE",
+                            "state": null,
+                            "city": "Berlin",
+                            "asn": 1,
+                            "longitude": 0,
+                            "latitude": 0,
+                            "network": "test",
+                            "tags": [],
+                            "resolvers": []
+                        },
+                        "result": {
+                            "status": "finished",
+                            "hops": [
+                                { "resolvedHostname": "h1", "resolvedAddress": "1.1.1.1", "asn": [ 64500, 64501 ] },
+                                { "resolvedHostname": "h2", "resolvedAddress": "2.2.2.2", "asn": [ 64502 ] }
+                            ]
+                        }
+                    }
+                ]
+            }
+            """;
+
+        var resp = JsonSerializer.Deserialize<MeasurementResponse>(json);
+        Assert.NotNull(resp);
+        var hops = resp!.GetMtrHops();
+        Assert.Equal(2, hops.Count);
+        Assert.Equal(new List<int> { 64500, 64501 }, hops[0].Asn);
+        Assert.Equal(new List<int> { 64502 }, hops[1].Asn);
     }
 }

--- a/Globalping/MtrHopResult.cs
+++ b/Globalping/MtrHopResult.cs
@@ -1,10 +1,12 @@
+using System.Collections.Generic;
+
 namespace Globalping;
 
 public class MtrHopResult
 {
     public string Target { get; set; } = string.Empty;
     public int Hop { get; set; }
-    public string Asn { get; set; } = string.Empty;
+    public List<int> Asn { get; set; } = new();
     public string Host { get; set; } = string.Empty;
     public string IpAddress { get; set; } = string.Empty;
     public double? LossPercent { get; set; }


### PR DESCRIPTION
## Summary
- represent `MtrHopResult.Asn` as a list of integers
- parse ASN arrays in `ParseMtr`
- handle raw MTR ASN values
- test that MTR hop ASN lists deserialize correctly

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684e91610188832e93d892896be57ad0