### PR TITLE
Add customizable Prefer wait time

### DIFF
--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -18,14 +18,14 @@ public static class ExecuteHttpExample {
             });
 
         var request = builder.Build();
-        request.InProgressUpdates = false;
+        request.InProgressUpdates = true;
 
         using var httpClient = new HttpClient(new HttpClientHandler {
             AutomaticDecompression = System.Net.DecompressionMethods.All
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
-        var measurementId = await probeService.CreateMeasurementAsync(request);
+        var measurementId = await probeService.CreateMeasurementAsync(request, 60);
 
         ConsoleHelpers.WriteHeading($"HTTP example (ID: {measurementId})");
 

--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -23,8 +23,8 @@ namespace Globalping.PowerShell;
 /// <example>
 ///   <summary>HTTP request with live updates</summary>
 ///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates</code>
-///   <para>Requests three probes and streams intermediate results.</para>
+///   <code>Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates -WaitTime 60</code>
+///   <para>Requests three probes and streams intermediate results for up to one minute.</para>
 /// </example>
 public abstract class StartGlobalpingBaseCommand : PSCmdlet
 {
@@ -66,6 +66,12 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
     /// arrive.</para>
     [Parameter]
     public SwitchParameter InProgressUpdates { get; set; }
+
+    /// <para>Time in seconds to wait for progress updates.</para>
+    /// <para>Only applies when <see cref="InProgressUpdates"/> is specified.</para>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int WaitTime { get; set; } = 150;
 
     /// <para>API key used to authenticate with Globalping.</para>
     /// <para>Anonymous requests may be rate limited.</para>
@@ -174,7 +180,7 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
         string id;
         try
         {
-            id = service.CreateMeasurementAsync(request).GetAwaiter().GetResult();
+            id = service.CreateMeasurementAsync(request, WaitTime).GetAwaiter().GetResult();
             WriteVerbose($"Measurement id: {id}");
         }
         catch (HttpRequestException ex)

--- a/Globalping.Tests/PreferHeaderTests.cs
+++ b/Globalping.Tests/PreferHeaderTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public sealed class PreferHeaderTests
+{
+    private sealed class CaptureHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{\"id\":\"1\"}", Encoding.UTF8, "application/json")
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    [Fact]
+    public async Task CreateMeasurementAsync_SetsPreferHeader()
+    {
+        var handler = new CaptureHandler();
+        var client = new HttpClient(handler);
+        var service = new ProbeService(client);
+
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .Build();
+        request.InProgressUpdates = true;
+
+        await service.CreateMeasurementAsync(request, 42);
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.True(handler.LastRequest!.Headers.TryGetValues("Prefer", out var values));
+        Assert.Contains("respond-async, wait=42", values);
+    }
+}

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -130,13 +130,15 @@ public class ProbeService {
     /// </summary>
     /// <param name="measurementRequest">Request payload describing the measurement.</param>
     /// <returns>Identifier of the created measurement.</returns>
-    public async Task<string> CreateMeasurementAsync(MeasurementRequest measurementRequest) {
+    public async Task<string> CreateMeasurementAsync(
+        MeasurementRequest measurementRequest,
+        int waitTime = 150) {
         var requestUri = "https://api.globalping.io/v1/measurements";
         var requestContent = new StringContent(JsonSerializer.Serialize(measurementRequest, _jsonOptions), Encoding.UTF8, "application/json");
 
         if (measurementRequest.InProgressUpdates) {
             _httpClient.DefaultRequestHeaders.Remove("Prefer");
-            _httpClient.DefaultRequestHeaders.Add("Prefer", "respond-async, wait=150");
+            _httpClient.DefaultRequestHeaders.Add("Prefer", $"respond-async, wait={waitTime}");
         }
 
         var response = await _httpClient.PostAsync(requestUri, requestContent).ConfigureAwait(false);
@@ -149,6 +151,8 @@ public class ProbeService {
     /// <summary>
     /// Synchronous wrapper for <see cref="CreateMeasurementAsync"/>.
     /// </summary>
-    public string CreateMeasurement(MeasurementRequest measurementRequest) =>
-        CreateMeasurementAsync(measurementRequest).GetAwaiter().GetResult();
+    public string CreateMeasurement(
+        MeasurementRequest measurementRequest,
+        int waitTime = 150) =>
+        CreateMeasurementAsync(measurementRequest, waitTime).GetAwaiter().GetResult();
 }

--- a/README.MD
+++ b/README.MD
@@ -95,6 +95,12 @@ To fetch only HTTP headers use `Start-GlobalpingHttp` with the `-HeadersOnly` pa
 Start-GlobalpingHttp -Target "https://example.com" -HeadersOnly
 ```
 
+Request in-progress updates and customize the wait time:
+
+```powershell
+Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates -WaitTime 60
+```
+
 The API specification is available at [api.globalping.io/v1/spec.yaml](https://api.globalping.io/v1/spec.yaml).
 
 By default both the .NET client and PowerShell module set helpful HTTP headers.


### PR DESCRIPTION
## Summary
- allow setting wait time for in-progress measurements
- expose WaitTime parameter on PowerShell cmdlets
- document usage and update example
- test Prefer header handling

## Testing
- `dotnet build Globalping.sln --configuration Release --no-restore`
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --no-build --configuration Release --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684e93ed2028832eba02ea730db58c71