### PR TITLE
Improve Get-GlobalpingLimit output

### DIFF
--- a/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
@@ -12,6 +12,7 @@ namespace Globalping.PowerShell;
 ///   <para>Returns rate limit information for the anonymous user or provided API key.</para>
 /// </example>
 [Cmdlet(VerbsCommon.Get, "GlobalpingLimit")]
+[OutputType(typeof(LimitInfo))]
 [OutputType(typeof(Limits))]
 [OutputType(typeof(Credits))]
 public class GetGlobalpingLimitCommand : PSCmdlet {
@@ -19,6 +20,11 @@ public class GetGlobalpingLimitCommand : PSCmdlet {
     [Parameter]
     [Alias("Token")]
     public string? ApiKey { get; set; }
+
+    /// <summary>Return the raw <see cref="Limits"/> object.</summary>
+    [Parameter]
+    [Alias("AsRaw")]
+    public SwitchParameter Raw { get; set; }
 
     /// <inheritdoc/>
     protected override void ProcessRecord() {
@@ -31,6 +37,21 @@ public class GetGlobalpingLimitCommand : PSCmdlet {
         });
         var service = new ProbeService(httpClient, ApiKey);
         var limits = service.GetLimitsAsync().GetAwaiter().GetResult();
-        WriteObject(limits);
+
+        if (Raw.IsPresent)
+        {
+            WriteObject(limits);
+            return;
+        }
+
+        if (limits is null)
+        {
+            return;
+        }
+
+        foreach (var info in limits.Flatten())
+        {
+            WriteObject(info);
+        }
     }
 }

--- a/Globalping.Tests/LimitInfoTests.cs
+++ b/Globalping.Tests/LimitInfoTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class LimitInfoTests
+{
+    [Fact]
+    public void FlattenProducesLimitInfo()
+    {
+        var json = """
+        {
+            "rateLimit": {
+                "measurements": {
+                    "create": { "type": "ip", "limit": 10, "remaining": 8, "reset": 1000 }
+                }
+            },
+            "credits": { "remaining": 42 }
+        }
+        """;
+
+        var limits = JsonSerializer.Deserialize<Limits>(json);
+        Assert.NotNull(limits);
+        var infos = new List<LimitInfo>(limits!.Flatten());
+        Assert.Single(infos);
+        var info = infos[0];
+        Assert.Equal("measurements", info.Category);
+        Assert.Equal("create", info.Action);
+        Assert.Equal("ip", info.Type);
+        Assert.Equal(10, info.Limit);
+        Assert.Equal(8, info.Remaining);
+        Assert.Equal(1000, info.Reset);
+        Assert.Equal(42, info.CreditsRemaining);
+    }
+}

--- a/Globalping/LimitInfo.cs
+++ b/Globalping/LimitInfo.cs
@@ -1,0 +1,28 @@
+namespace Globalping;
+
+/// <summary>
+/// Provides a flattened view of API limit information.
+/// </summary>
+public class LimitInfo
+{
+    /// <summary>Name of the rate limit category.</summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>Action within the category.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>Kind of limit applied by the API.</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Maximum number of allowed requests.</summary>
+    public int Limit { get; set; }
+
+    /// <summary>Number of requests remaining before the limit is reached.</summary>
+    public int Remaining { get; set; }
+
+    /// <summary>Epoch timestamp when the current window resets.</summary>
+    public long Reset { get; set; }
+
+    /// <summary>Credits still available for the authenticated user.</summary>
+    public int? CreditsRemaining { get; set; }
+}

--- a/Globalping/LimitsExtensions.cs
+++ b/Globalping/LimitsExtensions.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace Globalping;
+
+/// <summary>
+/// Extension helpers for <see cref="Limits"/>.
+/// </summary>
+public static class LimitsExtensions
+{
+    /// <summary>
+    /// Flattens nested rate limit information into friendly objects.
+    /// </summary>
+    /// <param name="limits">API limits returned by the service.</param>
+    /// <returns>Collection of <see cref="LimitInfo"/> objects.</returns>
+    public static IEnumerable<LimitInfo> Flatten(this Limits limits)
+    {
+        var credits = limits.Credits?.Remaining;
+        foreach (var category in limits.RateLimit)
+        {
+            foreach (var action in category.Value)
+            {
+                var detail = action.Value;
+                yield return new LimitInfo
+                {
+                    Category = category.Key,
+                    Action = action.Key,
+                    Type = detail.Type,
+                    Limit = detail.Limit,
+                    Remaining = detail.Remaining,
+                    Reset = detail.Reset,
+                    CreditsRemaining = credits
+                };
+            }
+        }
+    }
+}

--- a/Module/Examples/Example-Limits.ps1
+++ b/Module/Examples/Example-Limits.ps1
@@ -1,3 +1,7 @@
 Import-Module $PSScriptRoot\..\Globalping.psd1 -Force
 
-Get-GlobalpingLimit | Format-List
+# Display friendly limit information
+Get-GlobalpingLimit | Format-Table
+
+# Retrieve the raw Limits object
+Get-GlobalpingLimit -Raw | Format-List


### PR DESCRIPTION
## Summary
- expand Get-GlobalpingLimit to flatten rate limits and optionally output raw data
- add new `LimitInfo` model with helper extension
- add tests for the new flattening logic
- update example to show both friendly and raw output

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684e9833b2b8832eb69af30b1321794c