### PR TITLE
Fix ASN parsing for MTR results

### DIFF
--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -202,8 +202,8 @@ public class ResultParsingTests
         Assert.NotNull(resp);
         var hops = resp!.GetMtrHops();
         Assert.Equal(2, hops.Count);
-        Assert.Equal(new List<int> { 64500, 64501 }, hops[0].Asn);
-        Assert.Equal(new List<int> { 64502 }, hops[1].Asn);
+        Assert.Equal(new List<int> { 64500, 64501 }, Assert.IsType<List<int>>(hops[0].Asn));
+        Assert.Equal(64502, Assert.IsType<int>(hops[1].Asn));
     }
 
     [Fact]
@@ -246,6 +246,6 @@ public class ResultParsingTests
         Assert.NotNull(resp);
         var hops = resp!.GetMtrHops();
         Assert.Single(hops);
-        Assert.Equal(new List<int> { 64500 }, hops[0].Asn);
+        Assert.Equal(64500, Assert.IsType<int>(hops[0].Asn));
     }
 }

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -294,12 +294,17 @@ public static class MeasurementResponseExtensions {
                 }
                 if (hop.TryGetProperty("asn", out var asnEl)) {
                     if (asnEl.ValueKind == JsonValueKind.Array) {
-                        r.Asn = asnEl.EnumerateArray()
+                        var asns = asnEl.EnumerateArray()
                             .Where(a => a.ValueKind == JsonValueKind.Number)
                             .Select(a => a.GetInt32())
                             .ToList();
+                        r.Asn = asns.Count switch {
+                            0 => null,
+                            1 => (object)asns[0],
+                            _ => asns
+                        };
                     } else if (asnEl.ValueKind == JsonValueKind.Number) {
-                        r.Asn = new List<int> { asnEl.GetInt32() };
+                        r.Asn = asnEl.GetInt32();
                     }
                 }
                 if (hop.TryGetProperty("stats", out var statsEl)) {
@@ -358,7 +363,7 @@ public static class MeasurementResponseExtensions {
                     asnText = asnText.Substring(2);
                 }
                 if (int.TryParse(asnText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var asn)) {
-                    hop.Asn = new List<int> { asn };
+                    hop.Asn = asn;
                 }
                 if (double.TryParse(m.Groups[5].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var loss)) {
                     hop.LossPercent = loss;

--- a/Globalping/MtrHopResult.cs
+++ b/Globalping/MtrHopResult.cs
@@ -6,7 +6,7 @@ public class MtrHopResult
 {
     public string Target { get; set; } = string.Empty;
     public int Hop { get; set; }
-    public List<int> Asn { get; set; } = new();
+    public object? Asn { get; set; }
     public string Host { get; set; } = string.Empty;
     public string IpAddress { get; set; } = string.Empty;
     public double? LossPercent { get; set; }


### PR DESCRIPTION
## Summary
- parse ASN from MTR results as single int when only one value exists
- update `MtrHopResult` ASN type to `object?`
- adjust tests for new ASN behaviour

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ea0c4642c832ebec7172f2e40882e