### PR TITLE
Add error handling support

### DIFF
--- a/Globalping.Tests/ErrorHandlingTests.cs
+++ b/Globalping.Tests/ErrorHandlingTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public sealed class ErrorHandlingTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StubHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    [Fact]
+    public async Task CreateMeasurementAsync_ThrowsOnBadRequest()
+    {
+        const string json = "{\"error\":{\"type\":\"validation_error\",\"message\":\"Invalid\"}}";
+        var resp = new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        var client = new HttpClient(new StubHandler(resp));
+        var service = new ProbeService(client);
+        var request = new MeasurementRequest();
+
+        var ex = await Assert.ThrowsAsync<GlobalpingApiException>(() => service.CreateMeasurementAsync(request));
+        Assert.Equal("validation_error", ex.Error.Type);
+        Assert.Equal("Invalid", ex.Error.Message);
+        Assert.Equal((int)HttpStatusCode.BadRequest, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMeasurementByIdAsync_ThrowsOnNotFound()
+    {
+        const string json = "{\"error\":{\"type\":\"not_found\",\"message\":\"Missing\"}}";
+        var resp = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        var client = new HttpClient(new StubHandler(resp));
+        var measurementClient = new MeasurementClient(client);
+
+        var ex = await Assert.ThrowsAsync<GlobalpingApiException>(() => measurementClient.GetMeasurementByIdAsync("1"));
+        Assert.Equal("not_found", ex.Error.Type);
+        Assert.Equal("Missing", ex.Error.Message);
+        Assert.Equal((int)HttpStatusCode.NotFound, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMeasurementByIdAsync_ThrowsOnRateLimit()
+    {
+        const string json = "{\"error\":{\"type\":\"rate_limit_exceeded\",\"message\":\"Limit\"}}";
+        var resp = new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+
+        var client = new HttpClient(new StubHandler(resp));
+        var measurementClient = new MeasurementClient(client);
+
+        var ex = await Assert.ThrowsAsync<GlobalpingApiException>(() => measurementClient.GetMeasurementByIdAsync("1"));
+        Assert.Equal("rate_limit_exceeded", ex.Error.Type);
+        Assert.Equal("Limit", ex.Error.Message);
+        Assert.Equal(429, ex.StatusCode);
+    }
+}

--- a/Globalping/ErrorResponse.cs
+++ b/Globalping/ErrorResponse.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+/// <summary>
+/// Container for API error details returned in non-successful responses.
+/// </summary>
+public class ErrorResponse
+{
+    /// <summary>Error information.</summary>
+    [JsonPropertyName("error")]
+    public ErrorDetails Error { get; set; } = new();
+}
+
+/// <summary>
+/// Describes an error returned by the Globalping API.
+/// </summary>
+public class ErrorDetails
+{
+    /// <summary>Machine readable error type.</summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Human readable error message.</summary>
+    [JsonPropertyName("message")]
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>Additional error parameters when provided.</summary>
+    [JsonPropertyName("params")]
+    public Dictionary<string, string>? Params { get; set; }
+}

--- a/Globalping/GlobalpingApiException.cs
+++ b/Globalping/GlobalpingApiException.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Globalping;
+
+/// <summary>
+/// Exception thrown when the Globalping API returns an error response.
+/// </summary>
+public class GlobalpingApiException : Exception
+{
+    /// <summary>HTTP status code returned by the API.</summary>
+    public int StatusCode { get; }
+
+    /// <summary>Parsed error information.</summary>
+    public ErrorDetails Error { get; }
+
+    /// <summary>Usage info associated with the response.</summary>
+    public ApiUsageInfo UsageInfo { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GlobalpingApiException"/> class.
+    /// </summary>
+    /// <param name="statusCode">HTTP status code.</param>
+    /// <param name="error">Error details returned by the API.</param>
+    /// <param name="usageInfo">Captured usage information.</param>
+    public GlobalpingApiException(int statusCode, ErrorDetails error, ApiUsageInfo usageInfo)
+        : base(error?.Message)
+    {
+        StatusCode = statusCode;
+        Error = error;
+        UsageInfo = usageInfo;
+    }
+}


### PR DESCRIPTION
## Summary
- model API error objects and custom exception
- deserialize errors in ProbeService and MeasurementClient
- throw `GlobalpingApiException` on non-success codes
- cover bad request, not found and rate limit cases

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ea3e7e20c832e8657090d64343741