### PR TITLE
Remove unused MeasurementOptions class

### DIFF
--- a/Globalping/Models/IMeasurementOptions.cs
+++ b/Globalping/Models/IMeasurementOptions.cs
@@ -1,0 +1,3 @@
+﻿namespace Globalping;
+
+public interface IMeasurementOptions { }

--- a/Globalping/Models/MeasurementOptions.cs
+++ b/Globalping/Models/MeasurementOptions.cs
@@ -1,7 +1,0 @@
-﻿namespace Globalping;
-
-public interface IMeasurementOptions { }
-
-public class MeasurementOptions {
-    public int? Packets { get; set; } // Example custom option
-}


### PR DESCRIPTION
## Summary
- drop obsolete `MeasurementOptions` class
- keep `IMeasurementOptions` interface

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ea3f58a28832e9b6b3b3e1a516b87