### PR TITLE
Fix Prefer header handling

### DIFF
--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -136,8 +136,8 @@ public class ProbeService {
         var requestUri = "https://api.globalping.io/v1/measurements";
         var requestContent = new StringContent(JsonSerializer.Serialize(measurementRequest, _jsonOptions), Encoding.UTF8, "application/json");
 
+        _httpClient.DefaultRequestHeaders.Remove("Prefer");
         if (measurementRequest.InProgressUpdates) {
-            _httpClient.DefaultRequestHeaders.Remove("Prefer");
             _httpClient.DefaultRequestHeaders.Add("Prefer", $"respond-async, wait={waitTime}");
         }
 


### PR DESCRIPTION
## Summary
- always remove the `Prefer` header in `CreateMeasurementAsync`
- keep `Prefer` header only when `InProgressUpdates` is true
- verify the header is cleared in a new unit test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ea4045a1c832e8f23163430495088