### PR TITLE
Ensure status fields use enums

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -15,6 +15,7 @@ public sealed class MeasurementResponseDeserializationTests
     static MeasurementResponseDeserializationTests()
     {
         JsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
+        JsonOptions.Converters.Add(new JsonStringEnumConverter<TestStatus>(JsonNamingPolicy.KebabCaseLower));
         JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
     [Fact]

--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -16,6 +16,7 @@ public class ResultParsingTests
     static ResultParsingTests()
     {
         JsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
+        JsonOptions.Converters.Add(new JsonStringEnumConverter<TestStatus>(JsonNamingPolicy.KebabCaseLower));
         JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
 

--- a/Globalping/DnsRecordResult.cs
+++ b/Globalping/DnsRecordResult.cs
@@ -22,5 +22,5 @@ public class DnsRecordResult
     public int Asn { get; set; }
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
 }

--- a/Globalping/Enums/TestStatus.cs
+++ b/Globalping/Enums/TestStatus.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+public enum TestStatus
+{
+    InProgress,
+    Finished,
+    Failed,
+    Offline
+}

--- a/Globalping/HttpResponseResult.cs
+++ b/Globalping/HttpResponseResult.cs
@@ -18,5 +18,5 @@ public class HttpResponseResult
     public string Continent { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
 }

--- a/Globalping/MeasurementClient.cs
+++ b/Globalping/MeasurementClient.cs
@@ -31,6 +31,7 @@ public class MeasurementClient {
     public MeasurementClient(HttpClient httpClient, string? apiKey = null) {
         _httpClient = httpClient;
         _jsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
+        _jsonOptions.Converters.Add(new JsonStringEnumConverter<TestStatus>(JsonNamingPolicy.KebabCaseLower));
         _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 
         if (!_httpClient.DefaultRequestHeaders.UserAgent.Any()) {

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -116,7 +116,7 @@ public static class MeasurementResponseExtensions {
             Network = r.Probe.Network,
             ResolvedAddress = r.Data?.ResolvedAddress,
             ResolvedHostname = r.Data?.ResolvedHostname,
-            Status = r.Data?.Status,
+            Status = r.Data != null ? r.Data.Status : default,
             Timings = r.Data?.Timings,
             Stats = r.Data?.Stats
         }).ToList();
@@ -148,7 +148,7 @@ public static class MeasurementResponseExtensions {
                         Network = r.Probe.Network,
                         ResolvedAddress = r.Data?.ResolvedAddress,
                         ResolvedHostname = r.Data?.ResolvedHostname,
-                        Status = r.Data?.Status,
+                        Status = r.Data != null ? r.Data.Status : default,
                     };
                 }).ToList();
             }
@@ -173,7 +173,7 @@ public static class MeasurementResponseExtensions {
             h.Network = r.Probe.Network;
             h.ResolvedAddress = r.Data?.ResolvedAddress;
             h.ResolvedHostname = r.Data?.ResolvedHostname;
-            h.Status = r.Data?.Status;
+            h.Status = r.Data != null ? r.Data.Status : default;
             return h;
         })).ToList();
     }
@@ -194,7 +194,7 @@ public static class MeasurementResponseExtensions {
             h.Network = r.Probe.Network;
             h.ResolvedAddress = r.Data?.ResolvedAddress;
             h.ResolvedHostname = r.Data?.ResolvedHostname;
-            h.Status = r.Data?.Status;
+            h.Status = r.Data != null ? r.Data.Status : default;
             return h;
         })).ToList();
     }
@@ -213,7 +213,7 @@ public static class MeasurementResponseExtensions {
             h.State = r.Probe.State;
             h.Asn = r.Probe.Asn;
             h.Network = r.Probe.Network;
-            h.Status = r.Data?.Status;
+            h.Status = r.Data != null ? r.Data.Status : default;
             return h;
         })).ToList();
     }
@@ -519,7 +519,7 @@ public static class MeasurementResponseExtensions {
             h.Network = r.Probe.Network;
             h.ResolvedAddress = r.Data?.ResolvedAddress;
             h.ResolvedHostname = r.Data?.ResolvedHostname;
-            h.Status = r.Data?.Status;
+            h.Status = r.Data != null ? r.Data.Status : default;
             return h;
         })).ToList();
     }

--- a/Globalping/MtrHopResult.cs
+++ b/Globalping/MtrHopResult.cs
@@ -23,5 +23,5 @@ public class MtrHopResult
     public string Continent { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
 }

--- a/Globalping/PingTimingResult.cs
+++ b/Globalping/PingTimingResult.cs
@@ -16,5 +16,5 @@ public class PingTimingResult {
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
     public string? ResolvedHostname { get; set; }
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
 }

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -30,6 +30,7 @@ public class ProbeService {
     {
         _httpClient = httpClient;
         _jsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
+        _jsonOptions.Converters.Add(new JsonStringEnumConverter<TestStatus>(JsonNamingPolicy.KebabCaseLower));
         _jsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 
         if (!_httpClient.DefaultRequestHeaders.UserAgent.Any())

--- a/Globalping/Responses/ResultDetails.cs
+++ b/Globalping/Responses/ResultDetails.cs
@@ -6,7 +6,7 @@ namespace Globalping;
 
 public class ResultDetails {
     [JsonPropertyName("status")]
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
 
     [JsonPropertyName("rawOutput")]
     public string? RawOutput { get; set; }

--- a/Globalping/ResultExtensions.cs
+++ b/Globalping/ResultExtensions.cs
@@ -27,7 +27,7 @@ public static class ResultExtensions
                     Continent = result.Probe.Continent,
                     ResolvedAddress = result.Data?.ResolvedAddress,
                     ResolvedHostname = result.Data?.ResolvedHostname,
-                    Status = result.Data?.Status,
+                    Status = result.Data != null ? result.Data.Status : default,
                 };
             }).ToList();
         }
@@ -47,7 +47,7 @@ public static class ResultExtensions
             h.Continent = result.Probe.Continent;
             h.ResolvedAddress = result.Data?.ResolvedAddress;
             h.ResolvedHostname = result.Data?.ResolvedHostname;
-            h.Status = result.Data?.Status;
+            h.Status = result.Data != null ? result.Data.Status : default;
             return h;
         }).ToList();
     }
@@ -65,7 +65,7 @@ public static class ResultExtensions
             h.Continent = result.Probe.Continent;
             h.ResolvedAddress = result.Data?.ResolvedAddress;
             h.ResolvedHostname = result.Data?.ResolvedHostname;
-            h.Status = result.Data?.Status;
+            h.Status = result.Data != null ? result.Data.Status : default;
             return h;
         }).ToList();
     }
@@ -81,7 +81,7 @@ public static class ResultExtensions
             h.Asn = result.Probe.Asn;
             h.State = result.Probe.State;
             h.Continent = result.Probe.Continent;
-            h.Status = result.Data?.Status;
+            h.Status = result.Data != null ? result.Data.Status : default;
             return h;
         }).ToList();
     }
@@ -103,7 +103,7 @@ public static class ResultExtensions
         resp.Continent = result.Probe.Continent;
         resp.ResolvedAddress = result.Data?.ResolvedAddress;
         resp.ResolvedHostname = result.Data?.ResolvedHostname;
-        resp.Status = result.Data?.Status;
+        resp.Status = result.Data != null ? result.Data.Status : default;
         return resp;
     }
 }

--- a/Globalping/ResultSummary.cs
+++ b/Globalping/ResultSummary.cs
@@ -13,7 +13,7 @@ public class ResultSummary
     public string Network { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
     public JsonElement? Timings { get; set; }
     public Stats? Stats { get; set; }
 }

--- a/Globalping/TracerouteHopResult.cs
+++ b/Globalping/TracerouteHopResult.cs
@@ -17,5 +17,5 @@ public class TracerouteHopResult
     public string Continent { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
-    public string? Status { get; set; }
+    public TestStatus Status { get; set; }
 }


### PR DESCRIPTION
## Summary
- introduce `TestStatus` enum for probe results
- use `TestStatus` instead of strings in result models
- register new enum converter in client and probe service
- update tests for new enum

## Testing
- `dotnet restore Globalping.sln`
- `dotnet build Globalping.sln --configuration Release --no-restore`
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --configuration Release --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_684ea4b64614832ea6a57ace01a8e564