### PR TITLE
Add ETag caching support

### DIFF
--- a/Globalping.Tests/ETagCachingTests.cs
+++ b/Globalping.Tests/ETagCachingTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ETagCachingTests
+{
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+        public SequenceHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    [Fact]
+    public async Task ReturnsCachedMeasurementOnNotModified()
+    {
+        const string json = "{\"id\":\"1\",\"type\":\"ping\",\"status\":\"finished\",\"target\":\"example.com\",\"probesCount\":0}";
+        var first = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        first.Headers.ETag = new EntityTagHeaderValue("\"abc\"");
+
+        var second = new HttpResponseMessage(HttpStatusCode.NotModified);
+        second.Headers.ETag = new EntityTagHeaderValue("\"abc\"");
+
+        var client = new HttpClient(new SequenceHandler(first, second));
+        var measurementClient = new MeasurementClient(client);
+
+        var result1 = await measurementClient.GetMeasurementByIdAsync("1");
+        Assert.NotNull(result1);
+
+        var result2 = await measurementClient.GetMeasurementByIdAsync("1", measurementClient.LastResponseInfo.ETag);
+        Assert.Same(result1, result2);
+    }
+}

--- a/Globalping.Tests/UsageHeaderTests.cs
+++ b/Globalping.Tests/UsageHeaderTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,7 @@ public class UsageHeaderTests
         response.Headers.Add("X-Credits-Consumed", "2");
         response.Headers.Add("X-Credits-Remaining", "8");
         response.Headers.Add("X-Request-Cost", "2");
+        response.Headers.ETag = new EntityTagHeaderValue("\"abc\"");
 
         var client = new HttpClient(new MockHandler(response));
         var service = new ProbeService(client);
@@ -49,6 +51,7 @@ public class UsageHeaderTests
         Assert.Equal(2, service.LastResponseInfo.CreditsConsumed);
         Assert.Equal(8, service.LastResponseInfo.CreditsRemaining);
         Assert.Equal(2, service.LastResponseInfo.RequestCost);
+        Assert.Equal("\"abc\"", service.LastResponseInfo.ETag);
     }
 
     [Fact]
@@ -66,6 +69,7 @@ public class UsageHeaderTests
         response.Headers.Add("X-Credits-Consumed", "3");
         response.Headers.Add("X-Credits-Remaining", "7");
         response.Headers.Add("X-Request-Cost", "1");
+        response.Headers.ETag = new EntityTagHeaderValue("\"def\"");
 
         var client = new HttpClient(new MockHandler(response));
         var measurementClient = new MeasurementClient(client);
@@ -78,5 +82,6 @@ public class UsageHeaderTests
         Assert.Equal(3, measurementClient.LastResponseInfo.CreditsConsumed);
         Assert.Equal(7, measurementClient.LastResponseInfo.CreditsRemaining);
         Assert.Equal(1, measurementClient.LastResponseInfo.RequestCost);
+        Assert.Equal("\"def\"", measurementClient.LastResponseInfo.ETag);
     }
 }

--- a/Globalping/ApiUsageInfo.cs
+++ b/Globalping/ApiUsageInfo.cs
@@ -14,4 +14,5 @@ public class ApiUsageInfo
     public int? CreditsConsumed { get; set; }
     public int? CreditsRemaining { get; set; }
     public int? RequestCost { get; set; }
+    public string? ETag { get; set; }
 }

--- a/Globalping/MeasurementClient.cs
+++ b/Globalping/MeasurementClient.cs
@@ -22,6 +22,7 @@ public class MeasurementClient {
     };
 
     public ApiUsageInfo LastResponseInfo { get; private set; } = new();
+    public MeasurementResponse? LastMeasurement { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MeasurementClient"/> class.
@@ -61,7 +62,8 @@ public class MeasurementClient {
             RateLimitReset = TryGetLong(headers, "X-RateLimit-Reset"),
             CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
             CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
-            RequestCost = TryGetInt(headers, "X-Request-Cost")
+            RequestCost = TryGetInt(headers, "X-Request-Cost"),
+            ETag = headers.ETag?.Tag
         };
     }
 
@@ -110,7 +112,7 @@ public class MeasurementClient {
     /// </summary>
     /// <param name="id">Unique measurement identifier.</param>
     /// <returns>The full measurement response or <c>null</c> if not found.</returns>
-    public async Task<MeasurementResponse?> GetMeasurementByIdAsync(string id) {
+    public async Task<MeasurementResponse?> GetMeasurementByIdAsync(string id, string? etag = null) {
         if (string.IsNullOrWhiteSpace(id)) {
             throw new ArgumentException("Measurement id cannot be empty", nameof(id));
         }
@@ -119,7 +121,18 @@ public class MeasurementClient {
         MeasurementResponse? measurementResponse;
 
         do {
-            var response = await _httpClient.GetAsync(url).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (!string.IsNullOrEmpty(etag)) {
+                request.Headers.IfNoneMatch.ParseAdd(etag);
+            }
+
+            var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotModified) {
+                UpdateUsageInfo(response);
+                return LastMeasurement;
+            }
+
             await EnsureSuccessOrThrow(response).ConfigureAwait(false);
             var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
             measurementResponse = await JsonSerializer.DeserializeAsync<MeasurementResponse>(stream, _jsonOptions).ConfigureAwait(false);
@@ -130,6 +143,8 @@ public class MeasurementClient {
                     r.Target = measurementResponse.Target;
                 }
             }
+
+            LastMeasurement = measurementResponse;
 
             if (measurementResponse?.Status == MeasurementStatus.InProgress) {
                 await Task.Delay(500).ConfigureAwait(false);
@@ -142,6 +157,6 @@ public class MeasurementClient {
     /// <summary>
     /// Synchronous wrapper for <see cref="GetMeasurementByIdAsync"/>.
     /// </summary>
-    public MeasurementResponse? GetMeasurementById(string id) =>
-        GetMeasurementByIdAsync(id).GetAwaiter().GetResult();
+    public MeasurementResponse? GetMeasurementById(string id, string? etag = null) =>
+        GetMeasurementByIdAsync(id, etag).GetAwaiter().GetResult();
 }

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -66,7 +66,8 @@ public class ProbeService {
             RateLimitReset = TryGetLong(headers, "X-RateLimit-Reset"),
             CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
             CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
-            RequestCost = TryGetInt(headers, "X-Request-Cost")
+            RequestCost = TryGetInt(headers, "X-Request-Cost"),
+            ETag = headers.ETag?.Tag
         };
     }
 

--- a/README.MD
+++ b/README.MD
@@ -111,3 +111,8 @@ falls back to `gzip`.
 All API clients expose the most recent usage headers via the `LastResponseInfo`
 property. When the service returns values such as `X-RateLimit-Limit` or
 `X-Credits-Remaining` they will be parsed into this object for easy inspection.
+
+`MeasurementClient` supports basic caching via `ETag`. Pass the `LastResponseInfo.ETag`
+value to `GetMeasurementByIdAsync` or `GetMeasurementById`. When the API returns
+`304 Not Modified` the previously retrieved measurement data is reused and parsing
+is skipped.


### PR DESCRIPTION
## Summary
- track `ETag` headers in `ApiUsageInfo`
- store most recent measurement and `ETag` in `MeasurementClient`
- allow passing an `etag` when fetching measurements to use `If-None-Match`
- return cached data when server sends `304 Not Modified`
- document the new caching behavior
- test ETag header handling and caching logic

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ea7f1c710832e87936b6c725df715