### PR TITLE
Return probes count from CreateMeasurementAsync

### DIFF
--- a/Globalping.Examples/ConsoleHelpers.cs
+++ b/Globalping.Examples/ConsoleHelpers.cs
@@ -44,8 +44,12 @@ public static class ConsoleHelpers
         }
         else if (data is IDictionary dict)
         {
-            entries = dict.Cast<DictionaryEntry>()
-                .Select(e => new KeyValuePair<string, object?>(e.Key?.ToString() ?? string.Empty, e.Value));
+            var list = new List<KeyValuePair<string, object?>>();
+            foreach (DictionaryEntry entry in dict)
+            {
+                list.Add(new KeyValuePair<string, object?>(entry.Key?.ToString() ?? string.Empty, entry.Value));
+            }
+            entries = list;
         }
         else
         {

--- a/Globalping.Examples/Examples/ExecuteDnsExample.cs
+++ b/Globalping.Examples/Examples/ExecuteDnsExample.cs
@@ -29,14 +29,14 @@ public static class ExecuteDnsExample
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
-        var measurementId = await probeService.CreateMeasurementAsync(request);
+        var measurement = await probeService.CreateMeasurementAsync(request);
 
-        ConsoleHelpers.WriteHeading($"DNS example (ID: {measurementId})");
+        ConsoleHelpers.WriteHeading($"DNS example (ID: {measurement.Id})");
 
         var client = new MeasurementClient(httpClient, apiKey);
-        var result = await client.GetMeasurementByIdAsync(measurementId);
+        var result = await client.GetMeasurementByIdAsync(measurement.Id);
 
-        ConsoleHelpers.WriteJson(request, $"Request sent (DNS ID: {measurementId})");
+        ConsoleHelpers.WriteJson(request, $"Request sent (DNS ID: {measurement.Id})");
 
         if (result != null)
         {

--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -25,14 +25,14 @@ public static class ExecuteHttpExample {
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
-        var measurementId = await probeService.CreateMeasurementAsync(request, 60);
+        var measurement = await probeService.CreateMeasurementAsync(request, 60);
 
-        ConsoleHelpers.WriteHeading($"HTTP example (ID: {measurementId})");
+        ConsoleHelpers.WriteHeading($"HTTP example (ID: {measurement.Id})");
 
         var client = new MeasurementClient(httpClient, apiKey);
-        var result = await client.GetMeasurementByIdAsync(measurementId);
+        var result = await client.GetMeasurementByIdAsync(measurement.Id);
 
-        ConsoleHelpers.WriteJson(request, $"Request sent (HTTP ID: {measurementId})");
+        ConsoleHelpers.WriteJson(request, $"Request sent (HTTP ID: {measurement.Id})");
 
         if (result != null) {
             ConsoleHelpers.WriteJson(result, "Measurement result");

--- a/Globalping.Examples/Examples/ExecuteMeasurementExample.cs
+++ b/Globalping.Examples/Examples/ExecuteMeasurementExample.cs
@@ -25,14 +25,14 @@ public static class ExecuteMeasurementExample
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
-        var measurementId = await probeService.CreateMeasurementAsync(request);
+        var measurement = await probeService.CreateMeasurementAsync(request);
 
-        ConsoleHelpers.WriteHeading($"Ping example (ID: {measurementId})");
+        ConsoleHelpers.WriteHeading($"Ping example (ID: {measurement.Id})");
 
         var client = new MeasurementClient(httpClient, apiKey);
-        var result = await client.GetMeasurementByIdAsync(measurementId);
+        var result = await client.GetMeasurementByIdAsync(measurement.Id);
 
-        ConsoleHelpers.WriteJson(request, $"Request sent (Ping ID: {measurementId})");
+        ConsoleHelpers.WriteJson(request, $"Request sent (Ping ID: {measurement.Id})");
 
         if (result != null)
         {

--- a/Globalping.Examples/Examples/ExecuteMtrExample.cs
+++ b/Globalping.Examples/Examples/ExecuteMtrExample.cs
@@ -24,14 +24,14 @@ public static class ExecuteMtrExample
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
-        var measurementId = await probeService.CreateMeasurementAsync(request);
+        var measurement = await probeService.CreateMeasurementAsync(request);
 
-        ConsoleHelpers.WriteHeading($"MTR example (ID: {measurementId})");
+        ConsoleHelpers.WriteHeading($"MTR example (ID: {measurement.Id})");
 
         var client = new MeasurementClient(httpClient, apiKey);
-        var result = await client.GetMeasurementByIdAsync(measurementId);
+        var result = await client.GetMeasurementByIdAsync(measurement.Id);
 
-        ConsoleHelpers.WriteJson(request, $"Request sent (MTR ID: {measurementId})");
+        ConsoleHelpers.WriteJson(request, $"Request sent (MTR ID: {measurement.Id})");
 
         if (result != null)
         {

--- a/Globalping.Examples/Examples/ExecuteTracerouteExample.cs
+++ b/Globalping.Examples/Examples/ExecuteTracerouteExample.cs
@@ -24,14 +24,14 @@ public static class ExecuteTracerouteExample
         });
         var apiKey = Environment.GetEnvironmentVariable("GLOBALPING_TOKEN");
         var probeService = new ProbeService(httpClient, apiKey);
-        var measurementId = await probeService.CreateMeasurementAsync(request);
+        var measurement = await probeService.CreateMeasurementAsync(request);
 
-        ConsoleHelpers.WriteHeading($"Traceroute example (ID: {measurementId})");
+        ConsoleHelpers.WriteHeading($"Traceroute example (ID: {measurement.Id})");
 
         var client = new MeasurementClient(httpClient, apiKey);
-        var result = await client.GetMeasurementByIdAsync(measurementId);
+        var result = await client.GetMeasurementByIdAsync(measurement.Id);
 
-        ConsoleHelpers.WriteJson(request, $"Request sent (Traceroute ID: {measurementId})");
+        ConsoleHelpers.WriteJson(request, $"Request sent (Traceroute ID: {measurement.Id})");
 
         if (result != null)
         {

--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -177,25 +177,25 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
 
         WriteVerbose($"Request: {JsonSerializer.Serialize(request, jsonOptions)}");
 
-        string id;
+        CreateMeasurementResponse createResponse;
         try
         {
-            id = service.CreateMeasurementAsync(request, WaitTime).GetAwaiter().GetResult();
-            WriteVerbose($"Measurement id: {id}");
+            createResponse = service.CreateMeasurementAsync(request, WaitTime).GetAwaiter().GetResult();
+            WriteVerbose($"Measurement id: {createResponse.Id}");
         }
         catch (HttpRequestException ex)
         {
             WriteVerbose($"Request failed: {ex.Message}");
             throw;
         }
-        if (string.IsNullOrEmpty(id))
+        if (string.IsNullOrEmpty(createResponse.Id))
         {
             WriteError(new ErrorRecord(new InvalidOperationException("Measurement creation failed"), "CreateFailed", ErrorCategory.InvalidOperation, Target));
             return;
         }
 
         var client = new MeasurementClient(httpClient, ApiKey);
-        var result = client.GetMeasurementByIdAsync(id).GetAwaiter().GetResult();
+        var result = client.GetMeasurementByIdAsync(createResponse.Id).GetAwaiter().GetResult();
         WriteVerbose($"Response: {JsonSerializer.Serialize(result, jsonOptions)}");
 
         HandleOutput(result);

--- a/Globalping.Tests/ConsoleHelpersTests.cs
+++ b/Globalping.Tests/ConsoleHelpersTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Reflection;
+using Globalping.Examples;
+using Spectre.Console.Rendering;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ConsoleHelpersTests
+{
+    [Fact]
+    public void CreateTable_AcceptsGenericDictionary()
+    {
+        using var doc = JsonDocument.Parse("{\"key\":\"value\"}");
+        var element = doc.RootElement.GetProperty("key");
+        var data = new Dictionary<string, JsonElement> { ["key"] = element };
+
+        var method = typeof(ConsoleHelpers).GetMethod("CreateTable", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var table = method!.Invoke(null, new object[] { data });
+
+        Assert.IsAssignableFrom<IRenderable>(table);
+    }
+}

--- a/Globalping.Tests/Globalping.Tests.csproj
+++ b/Globalping.Tests/Globalping.Tests.csproj
@@ -28,6 +28,7 @@
 
         <ItemGroup>
                 <ProjectReference Include="../Globalping/Globalping.csproj" />
+                <ProjectReference Include="../Globalping.Examples/Globalping.Examples.csproj" />
         </ItemGroup>
 
 </Project>

--- a/Globalping.Tests/PreferHeaderTests.cs
+++ b/Globalping.Tests/PreferHeaderTests.cs
@@ -20,7 +20,7 @@ public sealed class PreferHeaderTests
             LastRequest = request;
             var response = new HttpResponseMessage(HttpStatusCode.Created)
             {
-                Content = new StringContent("{\"id\":\"1\"}", Encoding.UTF8, "application/json")
+                Content = new StringContent("{\"id\":\"1\",\"probesCount\":1}", Encoding.UTF8, "application/json")
             };
             return Task.FromResult(response);
         }

--- a/Globalping/Models/CreateMeasurementResponse.cs
+++ b/Globalping/Models/CreateMeasurementResponse.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+public class CreateMeasurementResponse {
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("probesCount")]
+    public int ProbesCount { get; set; }
+}

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -149,8 +149,8 @@ public class ProbeService {
     /// Creates a measurement request on the Globalping service.
     /// </summary>
     /// <param name="measurementRequest">Request payload describing the measurement.</param>
-    /// <returns>Identifier of the created measurement.</returns>
-    public async Task<string> CreateMeasurementAsync(
+    /// <returns>Information about the created measurement.</returns>
+    public async Task<CreateMeasurementResponse> CreateMeasurementAsync(
         MeasurementRequest measurementRequest,
         int waitTime = 150) {
         var requestUri = "https://api.globalping.io/v1/measurements";
@@ -163,14 +163,14 @@ public class ProbeService {
 
         var response = await _httpClient.PostAsync(requestUri, requestContent).ConfigureAwait(false);
         await EnsureSuccessOrThrow(response).ConfigureAwait(false);
-        var result = await response.Content.ReadFromJsonAsync<MeasurementResponse>(_jsonOptions).ConfigureAwait(false);
-        return result?.Id ?? string.Empty;
+        var result = await response.Content.ReadFromJsonAsync<CreateMeasurementResponse>(_jsonOptions).ConfigureAwait(false);
+        return result ?? new CreateMeasurementResponse();
     }
 
     /// <summary>
     /// Synchronous wrapper for <see cref="CreateMeasurementAsync"/>.
     /// </summary>
-    public string CreateMeasurement(
+    public CreateMeasurementResponse CreateMeasurement(
         MeasurementRequest measurementRequest,
         int waitTime = 150) =>
         CreateMeasurementAsync(measurementRequest, waitTime).GetAwaiter().GetResult();


### PR DESCRIPTION
## Summary
- define `CreateMeasurementResponse` with `Id` and `ProbesCount`
- adjust `ProbeService.CreateMeasurementAsync` to return the new type
- update PowerShell command and all example apps for new return
- adapt `PreferHeaderTests` test response

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ea7edad9c832e9cae5ed81912e7c9