### PR TITLE
Update tests to use HTTP 202

### DIFF
--- a/Globalping.Tests/PreferHeaderTests.cs
+++ b/Globalping.Tests/PreferHeaderTests.cs
@@ -18,7 +18,7 @@ public sealed class PreferHeaderTests
             CancellationToken cancellationToken)
         {
             LastRequest = request;
-            var response = new HttpResponseMessage(HttpStatusCode.Created)
+            var response = new HttpResponseMessage(HttpStatusCode.Accepted)
             {
                 Content = new StringContent("{\"id\":\"1\"}", Encoding.UTF8, "application/json")
             };


### PR DESCRIPTION
## Summary
- update mock response in `PreferHeaderTests` to use `HttpStatusCode.Accepted`

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684ea7eac2f0832ea51a91e8d90bdf9c