### PR TITLE
Fix support for PowerShell 5.1

### DIFF
--- a/Globalping.PowerShell/OnImportAndRemove.cs
+++ b/Globalping.PowerShell/OnImportAndRemove.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using System.Reflection;
+
+/// <summary>
+/// OnModuleImportAndRemove is a class that implements the IModuleAssemblyInitializer and IModuleAssemblyCleanup interfaces.
+/// This class is used to handle the assembly resolve event when the module is imported and removed.
+/// </summary>
+public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
+    /// <summary>
+    /// OnImport is called when the module is imported.
+    /// </summary>
+    public void OnImport() {
+        if (IsNetFramework()) {
+            AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
+        }
+    }
+
+    /// <summary>
+    /// OnRemove is called when the module is removed.
+    /// </summary>
+    /// <param name="module"></param>
+    public void OnRemove(PSModuleInfo module) {
+        if (IsNetFramework()) {
+            AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
+        }
+    }
+
+    /// <summary>
+    /// MyResolveEventHandler is a method that handles the AssemblyResolve event.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    private static Assembly? MyResolveEventHandler(object? sender, ResolveEventArgs args) {
+        var libDirectory = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location);
+        var directoriesToSearch = new List<string>();
+
+        if (!string.IsNullOrEmpty(libDirectory)) {
+            directoriesToSearch.Add(libDirectory);
+            if (Directory.Exists(libDirectory)) {
+                directoriesToSearch.AddRange(Directory.GetDirectories(libDirectory, "*", SearchOption.AllDirectories));
+            }
+        }
+
+        var requestedAssemblyName = new AssemblyName(args.Name).Name + ".dll";
+
+        foreach (var directory in directoriesToSearch) {
+            var assemblyPath = Path.Combine(directory, requestedAssemblyName);
+
+            if (File.Exists(assemblyPath)) {
+                try {
+                    return Assembly.LoadFrom(assemblyPath);
+                } catch (Exception ex) {
+                    Console.WriteLine($"Failed to load assembly from {assemblyPath}: {ex.Message}");
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determine if the current runtime is .NET Framework
+    /// </summary>
+    /// <returns></returns>
+    private bool IsNetFramework() {
+        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Determine if the current runtime is .NET Core
+    private bool IsNetCore() {
+        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determine if the current runtime is .NET 5 or higher
+    /// </summary>
+    /// <returns></returns>
+    private bool IsNet5OrHigher() {
+        return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase) ||
+               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase) ||
+               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 7", StringComparison.OrdinalIgnoreCase) ||
+               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 8", StringComparison.OrdinalIgnoreCase) ||
+               System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 9", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -99,7 +99,7 @@ Build-Module -ModuleName 'Globalping' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = $false
         NETBinaryModuleDocumenation       = $true
     }
 

--- a/Module/Globalping.psd1
+++ b/Module/Globalping.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute', 'Get-GlobalpingLimit')
+    CmdletsToExport      = @('Get-GlobalpingLimit', 'Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
This pull request introduces a new class `OnModuleImportAndRemove` to manage assembly resolution during module import and removal, updates the module build process, and adjusts the export order of cmdlets in the module manifest. Below is a breakdown of the most significant changes:

### Module Import and Removal Enhancements:
* **New class `OnModuleImportAndRemove`**: Implements `IModuleAssemblyInitializer` and `IModuleAssemblyCleanup` to handle assembly resolution when the module is imported or removed. Key features include detecting the runtime environment (`IsNetFramework`, `IsNetCore`, `IsNet5OrHigher`) and resolving assemblies dynamically using `MyResolveEventHandler`.

### Build Process Updates:
* **Build configuration change in `Build-Module.ps1`**: Modified the `RefreshPSD1Only` parameter from `$true` to `$false`, ensuring the `.psd1` file is refreshed as part of the build process rather than being skipped.

### Module Manifest Adjustments:
* **Cmdlet export order in `Globalping.psd1`**: Reordered exported cmdlets, moving `Get-GlobalpingLimit` to the beginning of the list for better organization.