### PR TITLE
Add probe version field

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -191,4 +191,48 @@ public sealed class MeasurementResponseDeserializationTests
         Assert.Equal(8080, opts.Port);
         Assert.Equal(HttpProtocol.HTTP, opts.Protocol);
     }
+
+    [Fact]
+    public void DeserializesProbeVersion()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "ping",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "results": [
+                {
+                    "probe": {
+                        "continent": "EU",
+                        "country": "DE",
+                        "city": "Berlin",
+                        "asn": 1,
+                        "longitude": 0,
+                        "latitude": 0,
+                        "network": "test",
+                        "tags": [],
+                        "resolvers": [],
+                        "version": "1.2.3"
+                    },
+                    "result": {
+                        "status": "finished",
+                        "timings": [ { "ttl": 64, "rtt": 1.0 } ]
+                    }
+                }
+            ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json, JsonOptions);
+        Assert.NotNull(response);
+        Assert.NotNull(response!.Results);
+        Assert.Single(response.Results!);
+        Assert.Equal("1.2.3", response.Results![0].Probe.Version);
+
+        var timings = response.GetPingTimings();
+        Assert.Single(timings);
+        Assert.Equal("1.2.3", timings[0].Version);
+    }
 }

--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -249,4 +249,45 @@ public class ResultParsingTests
         Assert.Single(hops);
         Assert.Equal(64500, Assert.IsType<int>(hops[0].Asn));
     }
+
+    [Fact]
+    public void SummaryIncludesProbeVersion()
+    {
+        var json = """
+            {
+                "id": "1",
+                "type": "ping",
+                "status": "finished",
+                "target": "example.com",
+                "probesCount": 1,
+                "results": [
+                    {
+                        "probe": {
+                            "continent": "EU",
+                            "region": "EU",
+                            "country": "DE",
+                            "state": null,
+                            "city": "Berlin",
+                            "asn": 1,
+                            "longitude": 0,
+                            "latitude": 0,
+                            "network": "test",
+                            "tags": [],
+                            "resolvers": [],
+                            "version": "2.0.0"
+                        },
+                        "result": {
+                            "status": "finished"
+                        }
+                    }
+                ]
+            }
+            """;
+
+        var resp = JsonSerializer.Deserialize<MeasurementResponse>(json, JsonOptions);
+        Assert.NotNull(resp);
+        var summaries = resp!.GetSummaries();
+        Assert.Single(summaries);
+        Assert.Equal("2.0.0", summaries[0].Version);
+    }
 }

--- a/Globalping/DnsRecordResult.cs
+++ b/Globalping/DnsRecordResult.cs
@@ -22,5 +22,6 @@ public class DnsRecordResult
     public int Asn { get; set; }
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
     public TestStatus Status { get; set; }
 }

--- a/Globalping/HttpResponseResult.cs
+++ b/Globalping/HttpResponseResult.cs
@@ -16,6 +16,7 @@ public class HttpResponseResult
     public int Asn { get; set; }
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
     public TestStatus Status { get; set; }

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -114,6 +114,7 @@ public static class MeasurementResponseExtensions {
             Continent = r.Probe.Continent,
             Asn = r.Probe.Asn,
             Network = r.Probe.Network,
+            Version = r.Probe.Version,
             ResolvedAddress = r.Data?.ResolvedAddress,
             ResolvedHostname = r.Data?.ResolvedHostname,
             Status = r.Data != null ? r.Data.Status : default,
@@ -146,6 +147,7 @@ public static class MeasurementResponseExtensions {
                         State = r.Probe.State,
                         Asn = r.Probe.Asn,
                         Network = r.Probe.Network,
+                        Version = r.Probe.Version,
                         ResolvedAddress = r.Data?.ResolvedAddress,
                         ResolvedHostname = r.Data?.ResolvedHostname,
                         Status = r.Data != null ? r.Data.Status : default,
@@ -171,6 +173,7 @@ public static class MeasurementResponseExtensions {
             h.State = r.Probe.State;
             h.Asn = r.Probe.Asn;
             h.Network = r.Probe.Network;
+            h.Version = r.Probe.Version;
             h.ResolvedAddress = r.Data?.ResolvedAddress;
             h.ResolvedHostname = r.Data?.ResolvedHostname;
             h.Status = r.Data != null ? r.Data.Status : default;
@@ -192,6 +195,7 @@ public static class MeasurementResponseExtensions {
             h.State = r.Probe.State;
             h.ProbeAsn = r.Probe.Asn;
             h.Network = r.Probe.Network;
+            h.Version = r.Probe.Version;
             h.ResolvedAddress = r.Data?.ResolvedAddress;
             h.ResolvedHostname = r.Data?.ResolvedHostname;
             h.Status = r.Data != null ? r.Data.Status : default;
@@ -213,6 +217,7 @@ public static class MeasurementResponseExtensions {
             h.State = r.Probe.State;
             h.Asn = r.Probe.Asn;
             h.Network = r.Probe.Network;
+            h.Version = r.Probe.Version;
             h.Status = r.Data != null ? r.Data.Status : default;
             return h;
         })).ToList();
@@ -522,6 +527,7 @@ public static class MeasurementResponseExtensions {
             h.State = r.Probe.State;
             h.Asn = r.Probe.Asn;
             h.Network = r.Probe.Network;
+            h.Version = r.Probe.Version;
             h.ResolvedAddress = r.Data?.ResolvedAddress;
             h.ResolvedHostname = r.Data?.ResolvedHostname;
             h.Status = r.Data != null ? r.Data.Status : default;

--- a/Globalping/MtrHopResult.cs
+++ b/Globalping/MtrHopResult.cs
@@ -21,6 +21,7 @@ public class MtrHopResult
     public int ProbeAsn { get; set; }
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
     public TestStatus Status { get; set; }

--- a/Globalping/PingTimingResult.cs
+++ b/Globalping/PingTimingResult.cs
@@ -15,6 +15,7 @@ public class PingTimingResult {
     public int Asn { get; set; }
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
     public string? ResolvedHostname { get; set; }
     public TestStatus Status { get; set; }
 }

--- a/Globalping/Responses/Probe.cs
+++ b/Globalping/Responses/Probe.cs
@@ -36,4 +36,7 @@ public class Probe {
 
     [JsonPropertyName("resolvers")]
     public List<string> Resolvers { get; set; } = new();
+
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
 }

--- a/Globalping/ResultExtensions.cs
+++ b/Globalping/ResultExtensions.cs
@@ -25,6 +25,7 @@ public static class ResultExtensions
                     Asn = result.Probe.Asn,
                     State = result.Probe.State,
                     Continent = result.Probe.Continent,
+                    Version = result.Probe.Version,
                     ResolvedAddress = result.Data?.ResolvedAddress,
                     ResolvedHostname = result.Data?.ResolvedHostname,
                     Status = result.Data != null ? result.Data.Status : default,
@@ -45,6 +46,7 @@ public static class ResultExtensions
             h.Asn = result.Probe.Asn;
             h.State = result.Probe.State;
             h.Continent = result.Probe.Continent;
+            h.Version = result.Probe.Version;
             h.ResolvedAddress = result.Data?.ResolvedAddress;
             h.ResolvedHostname = result.Data?.ResolvedHostname;
             h.Status = result.Data != null ? result.Data.Status : default;
@@ -63,6 +65,7 @@ public static class ResultExtensions
             h.ProbeAsn = result.Probe.Asn;
             h.State = result.Probe.State;
             h.Continent = result.Probe.Continent;
+            h.Version = result.Probe.Version;
             h.ResolvedAddress = result.Data?.ResolvedAddress;
             h.ResolvedHostname = result.Data?.ResolvedHostname;
             h.Status = result.Data != null ? result.Data.Status : default;
@@ -81,6 +84,7 @@ public static class ResultExtensions
             h.Asn = result.Probe.Asn;
             h.State = result.Probe.State;
             h.Continent = result.Probe.Continent;
+            h.Version = result.Probe.Version;
             h.Status = result.Data != null ? result.Data.Status : default;
             return h;
         }).ToList();
@@ -101,6 +105,7 @@ public static class ResultExtensions
         resp.Asn = result.Probe.Asn;
         resp.State = result.Probe.State;
         resp.Continent = result.Probe.Continent;
+        resp.Version = result.Probe.Version;
         resp.ResolvedAddress = result.Data?.ResolvedAddress;
         resp.ResolvedHostname = result.Data?.ResolvedHostname;
         resp.Status = result.Data != null ? result.Data.Status : default;

--- a/Globalping/ResultSummary.cs
+++ b/Globalping/ResultSummary.cs
@@ -11,6 +11,7 @@ public class ResultSummary
     public string Continent { get; set; } = string.Empty;
     public int Asn { get; set; }
     public string Network { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
     public TestStatus Status { get; set; }

--- a/Globalping/TracerouteHopResult.cs
+++ b/Globalping/TracerouteHopResult.cs
@@ -15,6 +15,7 @@ public class TracerouteHopResult
     public int Asn { get; set; }
     public string State { get; set; } = string.Empty;
     public string Continent { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
     public TestStatus Status { get; set; }


### PR DESCRIPTION
## Summary
- expose `version` in Probe response model
- propagate probe version to result objects
- update conversion utilities
- test deserializing probe version

## Testing
- `dotnet restore Globalping.sln --verbosity minimal`
- `dotnet build Globalping.sln --no-restore --verbosity minimal`
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684ec967a404832e91e5e3a79e7fcf72