### PR TITLE
Fix nullability warnings

### DIFF
--- a/Globalping.Examples/Examples/CheckLimitsExample.cs
+++ b/Globalping.Examples/Examples/CheckLimitsExample.cs
@@ -14,6 +14,6 @@ public static class CheckLimitsExample
         var limits = await service.GetLimitsAsync();
 
         ConsoleHelpers.WriteHeading("API limits");
-        ConsoleHelpers.WriteJson(limits);
+        ConsoleHelpers.WriteJson(limits!);
     }
 }

--- a/Globalping/GlobalpingApiException.cs
+++ b/Globalping/GlobalpingApiException.cs
@@ -22,11 +22,11 @@ public class GlobalpingApiException : Exception
     /// <param name="statusCode">HTTP status code.</param>
     /// <param name="error">Error details returned by the API.</param>
     /// <param name="usageInfo">Captured usage information.</param>
-    public GlobalpingApiException(int statusCode, ErrorDetails error, ApiUsageInfo usageInfo)
+    public GlobalpingApiException(int statusCode, ErrorDetails? error, ApiUsageInfo? usageInfo)
         : base(error?.Message)
     {
         StatusCode = statusCode;
-        Error = error;
-        UsageInfo = usageInfo;
+        Error = error ?? new ErrorDetails();
+        UsageInfo = usageInfo ?? new ApiUsageInfo();
     }
 }

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -26,7 +26,7 @@ public static class MeasurementResponseExtensions {
             return info;
         }
 
-        var lines = raw.Split('\n');
+        var lines = raw!.Split('\n');
         for (var i = 0; i < lines.Length; i++) {
             var t = lines[i].Trim();
             if (t.StartsWith(";; ->>HEADER<<-")) {
@@ -70,7 +70,7 @@ public static class MeasurementResponseExtensions {
             return dict;
         }
 
-        var lines = raw.Split('\n');
+        var lines = raw!.Split('\n');
         var start = false;
         foreach (var line in lines) {
             var t = line.Trim();


### PR DESCRIPTION
## Summary
- update `GlobalpingApiException` constructor to handle null parameters
- ensure raw strings are not null when splitting in `MeasurementResponseExtensions`
- assert non-null result when writing limits in example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ecd9eb4ac832ea9b350a2aca4b8e9