### PR TITLE
Add limit parameter to AddMagic

### DIFF
--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -101,4 +101,32 @@ public sealed class MeasurementRequestTests
         Assert.True(root.TryGetProperty("inProgressUpdates", out var prop));
         Assert.True(prop.GetBoolean());
     }
+
+    [Fact]
+    public void AddMagicWithLimitSetsLimit()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .AddMagic("Europe", 5)
+            .Build();
+
+        var loc = Assert.Single(request.Locations);
+        Assert.Equal("Europe", loc.Magic);
+        Assert.Equal(5, loc.Limit);
+    }
+
+    [Fact]
+    public void AddMagicWithoutLimitLeavesLimitNull()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .AddMagic("Europe")
+            .Build();
+
+        var loc = Assert.Single(request.Locations);
+        Assert.Equal("Europe", loc.Magic);
+        Assert.Null(loc.Limit);
+    }
 }

--- a/Globalping/MeasurementRequestBuilder.cs
+++ b/Globalping/MeasurementRequestBuilder.cs
@@ -76,9 +76,9 @@ public class MeasurementRequestBuilder
         return AddLocation(loc);
     }
 
-    public MeasurementRequestBuilder AddMagic(string magic)
+    public MeasurementRequestBuilder AddMagic(string magic, int? limit = null)
     {
-        var loc = new LocationRequest { Magic = magic };
+        var loc = new LocationRequest { Magic = magic, Limit = limit };
         return AddLocation(loc);
     }
 


### PR DESCRIPTION
## Summary
- allow specifying a limit when adding a magic location
- test AddMagic limit handling

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684ecef23004832e97bf79cad5cb0a94