### PR TITLE
Parse HTTP timings and TLS

### DIFF
--- a/Globalping.Tests/ResultParsingTests.cs
+++ b/Globalping.Tests/ResultParsingTests.cs
@@ -144,7 +144,9 @@ public class ResultParsingTests
                             "truncated": false,
                             "headers": { "content-type": "text/plain" },
                             "statusCode": 200,
-                            "statusCodeName": "OK"
+                            "statusCodeName": "OK",
+                            "timings": { "dns": 10 },
+                            "tls": { "keyType": "RSA" }
                         }
                     }
                 ]
@@ -160,6 +162,10 @@ public class ResultParsingTests
         Assert.True(http[0].Headers.ContainsKey("content-type"));
         Assert.Single(http[0].Headers["content-type"]);
         Assert.Equal("text/plain", http[0].Headers["content-type"][0]);
+        Assert.NotNull(http[0].Timings);
+        Assert.Equal(10, http[0].Timings!.Dns);
+        Assert.NotNull(http[0].Tls);
+        Assert.Equal(TlsKeyType.RSA, http[0].Tls!.KeyType);
     }
 
     [Fact]

--- a/Globalping/HttpResponseResult.cs
+++ b/Globalping/HttpResponseResult.cs
@@ -19,5 +19,7 @@ public class HttpResponseResult
     public string Version { get; set; } = string.Empty;
     public string? ResolvedAddress { get; set; }
     public string? ResolvedHostname { get; set; }
+    public HttpTimings? Timings { get; set; }
+    public TlsCertificate? Tls { get; set; }
     public TestStatus Status { get; set; }
 }

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -539,6 +539,14 @@ public static class MeasurementResponseExtensions {
         if (data == null) {
             return new List<HttpResponseResult>();
         }
+        HttpTimings? timings = null;
+        if (data.Timings is JsonElement timingsEl &&
+            timingsEl.ValueKind != JsonValueKind.Undefined &&
+            timingsEl.ValueKind != JsonValueKind.Null)
+        {
+            timings = JsonSerializer.Deserialize<HttpTimings>(timingsEl.GetRawText());
+        }
+
         if (data.RawHeaders != null) {
             var resp = new HttpResponseResult
             {
@@ -546,6 +554,8 @@ public static class MeasurementResponseExtensions {
                 StatusCode = data.StatusCode ?? 0,
                 StatusDescription = data.StatusCodeName ?? string.Empty,
                 Body = data.RawBody,
+                Timings = timings,
+                Tls = data.Tls,
             };
             if (data.Headers != null)
             {
@@ -608,6 +618,9 @@ public static class MeasurementResponseExtensions {
         if (index < lines.Length) {
             result.Body = string.Join("\n", lines.Skip(index));
         }
+
+        result.Timings = timings;
+        result.Tls = data.Tls;
 
         return new List<HttpResponseResult> { result };
     }


### PR DESCRIPTION
## Summary
- capture HTTP timings and TLS info in `HttpResponseResult`
- parse `timings` and `tls` from `ResultDetails`
- verify the parsing logic in `ResultParsingTests`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ecef57608832e9b44cfd3d0da355c