### PR TITLE
Add DNS resolver and timing info

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -235,4 +235,53 @@ public sealed class MeasurementResponseDeserializationTests
         Assert.Single(timings);
         Assert.Equal("1.2.3", timings[0].Version);
     }
+
+    [Fact]
+    public void DeserializesDnsResolverAndTimings()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "dns",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "results": [
+                {
+                    "probe": {
+                        "continent": "OC",
+                        "country": "AU",
+                        "city": "Melbourne",
+                        "asn": 1,
+                        "longitude": 0,
+                        "latitude": 0,
+                        "network": "test",
+                        "tags": [],
+                        "resolvers": []
+                    },
+                    "result": {
+                        "status": "finished",
+                        "resolver": "8.8.8.8",
+                        "statusCode": 0,
+                        "statusCodeName": "NOERROR",
+                        "timings": { "total": 42.0 },
+                        "answers": [
+                            { "name": "example.com", "type": "A", "ttl": 60, "class": "IN", "value": "1.1.1.1" }
+                        ]
+                    }
+                }
+            ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json, JsonOptions);
+        Assert.NotNull(response);
+        var records = response!.GetDnsRecords();
+        Assert.Single(records);
+        Assert.Equal("8.8.8.8", records[0].Resolver);
+        Assert.Equal(0, records[0].StatusCode);
+        Assert.Equal("NOERROR", records[0].StatusCodeName);
+        Assert.NotNull(records[0].Timings);
+        Assert.Equal(42.0, records[0].Timings!.Total);
+    }
 }

--- a/Globalping/DnsRecordResult.cs
+++ b/Globalping/DnsRecordResult.cs
@@ -16,6 +16,10 @@ public class DnsRecordResult
     public int Ttl { get; set; }
     public string Type { get; set; } = string.Empty;
     public string Data { get; set; } = string.Empty;
+    public string Resolver { get; set; } = string.Empty;
+    public int StatusCode { get; set; }
+    public string StatusCodeName { get; set; } = string.Empty;
+    public DnsTimings? Timings { get; set; }
     public string Country { get; set; } = string.Empty;
     public string City { get; set; } = string.Empty;
     public string Network { get; set; } = string.Empty;

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -395,6 +395,14 @@ public static class MeasurementResponseExtensions {
     }
 
     internal static List<DnsRecordResult> ParseDns(ResultDetails? data) {
+        var resolver = data?.Resolver ?? string.Empty;
+        var statusCode = data?.StatusCode ?? 0;
+        var statusCodeName = data?.StatusCodeName ?? string.Empty;
+        DnsTimings? timings = null;
+        if (data?.Timings is JsonElement tEl && tEl.ValueKind == JsonValueKind.Object) {
+            timings = JsonSerializer.Deserialize<DnsTimings>(tEl.GetRawText());
+        }
+
         if (data?.Answers != null && data.Answers.Count > 0) {
             var header = ParseDnsHeaderInfo(data.RawOutput);
             return data.Answers.Select(a => new DnsRecordResult {
@@ -410,7 +418,11 @@ public static class MeasurementResponseExtensions {
                 QueryCount = header.QueryCount,
                 AnswerCount = header.AnswerCount,
                 AuthorityCount = header.AuthorityCount,
-                AdditionalCount = header.AdditionalCount
+                AdditionalCount = header.AdditionalCount,
+                Resolver = resolver,
+                StatusCode = statusCode,
+                StatusCodeName = statusCodeName,
+                Timings = timings
             }).ToList();
         }
         if (data?.Hops is JsonElement hops && hops.ValueKind == JsonValueKind.Array) {
@@ -419,11 +431,22 @@ public static class MeasurementResponseExtensions {
                 if (hop.TryGetProperty("answers", out var ansEl) && ansEl.ValueKind == JsonValueKind.Array) {
                     var ans = JsonSerializer.Deserialize<List<DnsAnswer>>(ansEl.GetRawText());
                     if (ans != null) {
+                        var hopResolver = hop.TryGetProperty("resolver", out var resEl) ? resEl.GetString() ?? resolver : resolver;
+                        var hopStatusCode = hop.TryGetProperty("statusCode", out var scEl) && scEl.ValueKind == JsonValueKind.Number ? scEl.GetInt32() : statusCode;
+                        var hopStatusName = hop.TryGetProperty("statusCodeName", out var scnEl) ? scnEl.GetString() ?? statusCodeName : statusCodeName;
+                        DnsTimings? hopTimings = timings;
+                        if (hop.TryGetProperty("timings", out var tEl2) && tEl2.ValueKind == JsonValueKind.Object) {
+                            hopTimings = JsonSerializer.Deserialize<DnsTimings>(tEl2.GetRawText());
+                        }
                         records.AddRange(ans.Select(a => new DnsRecordResult {
                             Name = a.Name,
                             Ttl = a.Ttl,
                             Type = a.Type,
-                            Data = a.Value
+                            Data = a.Value,
+                            Resolver = hopResolver,
+                            StatusCode = hopStatusCode,
+                            StatusCodeName = hopStatusName,
+                            Timings = hopTimings
                         }));
                     }
                 }
@@ -504,7 +527,11 @@ public static class MeasurementResponseExtensions {
                         Name = m.Groups[1].Value,
                         Ttl = int.Parse(m.Groups[2].Value),
                         Type = m.Groups[3].Value,
-                        Data = m.Groups[4].Value
+                        Data = m.Groups[4].Value,
+                        Resolver = resolver,
+                        StatusCode = statusCode,
+                        StatusCodeName = statusCodeName,
+                        Timings = timings
                     };
                     list.Add(rec);
                 }


### PR DESCRIPTION
## Summary
- add resolver, status code and timing info to `DnsRecordResult`
- parse resolver/status from API responses in `ParseDns`
- test DNS deserialization with resolver and timing data

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ecef39684832e8b013782a68b4db6