### PR TITLE
Add limit validation and tests

### DIFF
--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -59,6 +59,7 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
     /// <para>If omitted the cmdlet estimates a value based on provided
     /// locations.</para>
     [Parameter]
+    [ValidateRange(1, 500)]
     public int? Limit { get; set; }
 
     /// <para>Request progress updates while the measurement runs.</para>

--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -44,4 +44,14 @@ Describe "Globalping Cmdlets" {
         $limits = Get-GlobalpingLimit -ErrorAction Stop
         $limits | Should -Not -BeNullOrEmpty
     }
+
+    It "Rejects limit below valid range" {
+        { Start-GlobalpingPing -Target "evotec.xyz" -Limit 0 -ErrorAction Stop } |
+            Should -Throw -ErrorId 'ParameterArgumentValidationError,Globalping.PowerShell.StartGlobalpingPingCommand'
+    }
+
+    It "Rejects limit above valid range" {
+        { Start-GlobalpingPing -Target "evotec.xyz" -Limit 501 -ErrorAction Stop } |
+            Should -Throw -ErrorId 'ParameterArgumentValidationError,Globalping.PowerShell.StartGlobalpingPingCommand'
+    }
 }


### PR DESCRIPTION
## Summary
- validate the `Limit` parameter range in StartGlobalpingBaseCommand
- cover invalid limit values in Pester tests

## Testing
- `pwsh -NoLogo -File Module/Globalping.Tests.ps1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684ed3c4d354832eb20b6af4bd6f413d