### PR TITLE
Add Get-GlobalpingProbe cmdlet

### DIFF
--- a/Module/Examples/Example-Probes.ps1
+++ b/Module/Examples/Example-Probes.ps1
@@ -1,0 +1,7 @@
+Import-Module $PSScriptRoot\..\Globalping.psd1 -Force
+
+# Display flattened probe information
+Get-GlobalpingProbe | Format-Table
+
+# Retrieve the raw probe objects
+Get-GlobalpingProbe -Raw | Format-Table

--- a/Module/Globalping.psd1
+++ b/Module/Globalping.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Get-GlobalpingLimit', 'Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute')
+    CmdletsToExport      = @('Get-GlobalpingLimit', 'Get-GlobalpingProbe', 'Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -44,4 +44,9 @@ Describe "Globalping Cmdlets" {
         $limits = Get-GlobalpingLimit -ErrorAction Stop
         $limits | Should -Not -BeNullOrEmpty
     }
+
+    It "Get-GlobalpingProbe returns output" {
+        $probes = Get-GlobalpingProbe -ErrorAction Stop
+        $probes | Should -Not -BeNullOrEmpty
+    }
 }

--- a/README.MD
+++ b/README.MD
@@ -115,6 +115,18 @@ Request in-progress updates and customize the wait time:
 Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates -WaitTime 60
 ```
 
+List currently available probes:
+
+```powershell
+Get-GlobalpingProbe | Format-Table
+```
+
+Return the raw `Probes` objects:
+
+```powershell
+Get-GlobalpingProbe -Raw | Format-Table
+```
+
 ## C# usage
 
 The .NET library exposes the same functionality for applications. A minimal example to run a ping measurement:


### PR DESCRIPTION
## Summary
- add `GetGlobalpingProbeCommand` to Globalping.PowerShell
- export new command in module manifest and add example
- document probe retrieval in README
- test new cmdlet

## Testing
- `dotnet build Globalping.sln`
- `pwsh -NoLogo -NoProfile -Command ./Module/Globalping.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684ed3c60cf8832e8acd5a317169e9e5