### PR TITLE
Extend cmdlet tests

### DIFF
--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -30,6 +30,13 @@ Describe "Globalping Cmdlets" {
         $results.Target | Should -Be "evotec.xyz"
     }
 
+    It "Start-GlobalpingHttp returns headers when HeadersOnly is set" {
+        $results = Start-GlobalpingHttp -Target "evotec.xyz" -Limit 1 -HeadersOnly -ErrorAction Stop
+        $results | Should -Not -BeNullOrEmpty
+        $header = $results | Select-Object -First 1
+        ($header -is [System.Collections.IDictionary]) | Should -BeTrue
+    }
+
     It "Start-GlobalpingTraceroute returns output" {
         $results = Start-GlobalpingTraceroute -Target "evotec.xyz" -Limit 1 -ErrorAction Stop
         $results | Should -Not -BeNullOrEmpty
@@ -38,6 +45,36 @@ Describe "Globalping Cmdlets" {
     It "Start-GlobalpingMtr returns output" {
         $results = Start-GlobalpingMtr -Target "evotec.xyz" -Limit 1 -ErrorAction Stop
         $results | Should -Not -BeNullOrEmpty
+    }
+
+    It "Start-GlobalpingDns classic output returns string" {
+        $results = Start-GlobalpingDns -Target "evotec.xyz" -Limit 1 -Classic -ErrorAction Stop
+        $results | Should -Not -BeNullOrEmpty
+        $output = $results | Select-Object -First 1
+        $output | Should -BeOfType [string]
+    }
+
+    It "Start-GlobalpingMtr classic output returns string" {
+        $results = Start-GlobalpingMtr -Target "evotec.xyz" -Limit 1 -Classic -ErrorAction Stop
+        $results | Should -Not -BeNullOrEmpty
+        $output = $results | Select-Object -First 1
+        $output | Should -BeOfType [string]
+    }
+
+    It "Start-GlobalpingPing accepts PingOptions object" {
+        $opts = [Globalping.PingOptions]@{ Packets = 2 }
+        $results = Start-GlobalpingPing -Target "evotec.xyz" -Limit 1 -Options $opts -ErrorAction Stop
+        $results | Should -Not -BeNullOrEmpty
+        $result = $results | Select-Object -First 1
+        $result | Should -BeOfType [Globalping.PingTimingResult]
+    }
+
+    It "Start-GlobalpingHttp accepts HttpOptions object" {
+        $opts = [Globalping.HttpOptions]@{ Port = 443 }
+        $results = Start-GlobalpingHttp -Target "https://evotec.xyz" -Limit 1 -Options $opts -ErrorAction Stop
+        $results | Should -Not -BeNullOrEmpty
+        $result = $results | Select-Object -First 1
+        $result | Should -BeOfType [Globalping.HttpResponseResult]
     }
 
     It "Get-GlobalpingLimit returns output" {


### PR DESCRIPTION
## Summary
- add extra Cmdlets tests for headers only output, classic output, and options objects

## Testing
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./Module/Globalping.psd1 -Force; Invoke-Pester ./Module/Tests/Cmdlets.Tests.ps1 -Passthru"`

------
https://chatgpt.com/codex/tasks/task_e_684ed3c71890832eaec0a8fa8f3a63f8