### PR TITLE
Increase API test coverage

### DIFF
--- a/Globalping.Tests/MeasurementClientPollingTests.cs
+++ b/Globalping.Tests/MeasurementClientPollingTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class MeasurementClientPollingTests
+{
+    private sealed class SequenceHandler : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public SequenceHandler(params HttpResponseMessage[] responses)
+        {
+            _responses = new Queue<HttpResponseMessage>(responses);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    [Fact]
+    public async Task GetMeasurementByIdAsync_RetriesUntilFinished()
+    {
+        const string firstJson = "{\"id\":\"1\",\"type\":\"ping\",\"status\":\"in-progress\",\"target\":\"example.com\",\"probesCount\":0}";
+        const string secondJson = "{\"id\":\"1\",\"type\":\"ping\",\"status\":\"finished\",\"target\":\"example.com\",\"probesCount\":0}";
+        var first = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(firstJson, Encoding.UTF8, "application/json")
+        };
+        var second = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(secondJson, Encoding.UTF8, "application/json")
+        };
+
+        var handler = new SequenceHandler(first, second);
+        var client = new HttpClient(handler);
+        var measurementClient = new MeasurementClient(client);
+
+        var result = await measurementClient.GetMeasurementByIdAsync("1");
+
+        Assert.NotNull(result);
+        Assert.Equal(MeasurementStatus.Finished, result!.Status);
+        Assert.Equal(2, handler.CallCount);
+    }
+}

--- a/Globalping.Tests/ProbeServiceCoreTests.cs
+++ b/Globalping.Tests/ProbeServiceCoreTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ProbeServiceCoreTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+        private readonly HttpResponseMessage _response;
+        public StubHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    [Fact]
+    public async Task GetOnlineProbesAsync_ParsesProbeList()
+    {
+        var json = "[{\"version\":\"1.0\",\"location\":{\"continent\":\"EU\",\"region\":\"EU\",\"country\":\"DE\",\"state\":\"BY\",\"city\":\"Berlin\",\"asn\":1,\"network\":\"net\",\"latitude\":1.2,\"longitude\":3.4},\"tags\":[\"edge\"],\"resolvers\":[\"1.1.1.1\"]}]";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new StubHandler(response);
+        var client = new HttpClient(handler);
+        var service = new ProbeService(client);
+
+        var probes = await service.GetOnlineProbesAsync();
+
+        Assert.Single(probes);
+        Assert.Equal("1.0", probes[0].Version);
+        Assert.NotNull(probes[0].Location);
+        Assert.Equal("Berlin", probes[0].Location!.City);
+        Assert.Contains("edge", probes[0].Tags!);
+    }
+
+    [Fact]
+    public async Task GetLimitsAsync_ParsesLimits()
+    {
+        var json = "{\"rateLimit\":{\"measurements\":{\"create\":{\"type\":\"ip\",\"limit\":10,\"remaining\":8,\"reset\":1000}}},\"credits\":{\"remaining\":42}}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new StubHandler(response);
+        var client = new HttpClient(handler);
+        var service = new ProbeService(client);
+
+        var limits = await service.GetLimitsAsync();
+
+        Assert.NotNull(limits);
+        Assert.Equal(42, limits!.Credits!.Remaining);
+        Assert.Equal(10, limits.RateLimit["measurements"]["create"].Limit);
+    }
+}


### PR DESCRIPTION
## Summary
- add polling behavior test for MeasurementClient
- add tests for ProbeService limits and probe parsing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684ed9d865d0832e801598bac47c4d6f