### PR TITLE
Fix nullability warnings

### DIFF
--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -111,7 +111,7 @@ public sealed class MeasurementRequestTests
             .AddMagic("Europe", 5)
             .Build();
 
-        var loc = Assert.Single(request.Locations);
+        var loc = Assert.Single(request.Locations!);
         Assert.Equal("Europe", loc.Magic);
         Assert.Equal(5, loc.Limit);
     }
@@ -125,7 +125,7 @@ public sealed class MeasurementRequestTests
             .AddMagic("Europe")
             .Build();
 
-        var loc = Assert.Single(request.Locations);
+        var loc = Assert.Single(request.Locations!);
         Assert.Equal("Europe", loc.Magic);
         Assert.Null(loc.Limit);
     }


### PR DESCRIPTION
## Summary
- fix potential null arguments by using null-forgiving operator

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684ee2a7f828832eb49d84979a277d40