### PR TITLE
Fix parsing of optional ping statistics

### DIFF
--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -284,4 +284,46 @@ public sealed class MeasurementResponseDeserializationTests
         Assert.NotNull(records[0].Timings);
         Assert.Equal(42.0, records[0].Timings!.Total);
     }
+
+    [Fact]
+    public void DeserializesStatsWithNullableValues()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "ping",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 1,
+            "results": [
+                {
+                    "probe": {
+                        "continent": "EU",
+                        "country": "DE",
+                        "city": "Berlin",
+                        "asn": 1,
+                        "longitude": 0,
+                        "latitude": 0,
+                        "network": "test",
+                        "tags": [],
+                        "resolvers": []
+                    },
+                    "result": {
+                        "status": "finished",
+                        "stats": { "min": null, "max": 2.0, "avg": 1.5, "loss": null }
+                    }
+                }
+            ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<MeasurementResponse>(json, JsonOptions);
+        Assert.NotNull(response);
+        var stats = response!.Results![0].Data.Stats;
+        Assert.NotNull(stats);
+        Assert.Null(stats!.Min);
+        Assert.Equal(2.0, stats.Max);
+        Assert.Equal(1.5, stats.Avg);
+        Assert.Null(stats.Loss);
+    }
 }

--- a/Globalping/Responses/Stats.cs
+++ b/Globalping/Responses/Stats.cs
@@ -3,25 +3,25 @@ namespace Globalping;
 
 public class Stats {
     [JsonPropertyName("min")]
-    public double Min { get; set; }
+    public double? Min { get; set; }
 
     [JsonPropertyName("max")]
-    public double Max { get; set; }
+    public double? Max { get; set; }
 
     [JsonPropertyName("avg")]
-    public double Avg { get; set; }
+    public double? Avg { get; set; }
 
     [JsonPropertyName("total")]
-    public int Total { get; set; }
+    public int? Total { get; set; }
 
     [JsonPropertyName("loss")]
-    public double Loss { get; set; }
+    public double? Loss { get; set; }
 
     [JsonPropertyName("rcv")]
-    public int Rcv { get; set; }
+    public int? Rcv { get; set; }
 
     [JsonPropertyName("drop")]
-    public int Drop { get; set; }
+    public int? Drop { get; set; }
 
     [JsonPropertyName("stDev")]
     public double? StDev { get; set; }


### PR DESCRIPTION
## Summary
- make ping statistics nullable so parsing works when values are missing

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --verbosity normal`
- `pwsh ./Module/Globalping.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_684ee2eee054832eb9a40f88c8d50789