### PR TITLE
Add additional unit tests

### DIFF
--- a/Globalping.Tests/ExtensionParsingTests.cs
+++ b/Globalping.Tests/ExtensionParsingTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ExtensionParsingTests
+{
+    [Fact]
+    public void RegionNameTryParse_ValidString_ReturnsTrue()
+    {
+        var success = RegionNameExtensions.TryParse("Northern Europe", out var region);
+        Assert.True(success);
+        Assert.Equal(RegionName.NorthernEurope, region);
+    }
+
+    [Fact]
+    public void RegionNameTryParse_InvalidString_ReturnsFalse()
+    {
+        var success = RegionNameExtensions.TryParse("Unknown Region", out var region);
+        Assert.False(success);
+        Assert.Equal(default, region);
+    }
+
+    [Fact]
+    public void RegionNameToValueString_ReturnsExpected()
+    {
+        var str = RegionName.NorthernEurope.ToValueString();
+        Assert.Equal("Northern Europe", str);
+    }
+
+    [Fact]
+    public void ContinentCodeTryParse_ParsesCaseInsensitive()
+    {
+        var success = ContinentCodeExtensions.TryParse("eu", out var code);
+        Assert.True(success);
+        Assert.Equal(ContinentCode.EU, code);
+    }
+}

--- a/Globalping.Tests/ResultExtensionsTests.cs
+++ b/Globalping.Tests/ResultExtensionsTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ResultExtensionsTests
+{
+    [Fact]
+    public void ToPingTimings_ReturnsParsedTimings()
+    {
+        var timingsJson = JsonSerializer.SerializeToElement(new[]
+        {
+            new Timing { Ttl = 64, Rtt = 1.2 },
+            new Timing { Ttl = 64, Rtt = 1.5 }
+        });
+
+        var result = new Result
+        {
+            Probe = new Probe { Country = "DE", City = "Berlin", Network = "net", Asn = 1, State = "BE", Continent = "EU", Version = "1" },
+            Data = new ResultDetails { Timings = timingsJson, ResolvedAddress = "1.1.1.1", ResolvedHostname = "host" }
+        };
+
+        var list = result.ToPingTimings("example.com");
+        Assert.Equal(2, list.Count);
+        Assert.Equal("example.com", list[0].Target);
+        Assert.Equal(1, list[0].IcmpSequence);
+        Assert.Equal(64, list[0].TTL);
+        Assert.Equal(1.2, list[0].Time);
+        Assert.Equal("DE", list[0].Country);
+        Assert.Equal("host", list[0].ResolvedHostname);
+    }
+
+    [Fact]
+    public void ToHttpResponse_ParsesRawOutput()
+    {
+        var details = new ResultDetails
+        {
+            RawOutput = "HTTP/1.1 200 OK\nContent-Type: text/plain\n\nhello"
+        };
+        var result = new Result
+        {
+            Probe = new Probe(),
+            Data = details
+        };
+
+        var http = result.ToHttpResponse("example.com");
+        Assert.NotNull(http);
+        Assert.Equal("HTTP/1.1", http!.Protocol);
+        Assert.Equal(200, http.StatusCode);
+        Assert.Equal("hello", http.Body);
+        Assert.True(http.Headers.ContainsKey("Content-Type"));
+    }
+}


### PR DESCRIPTION
## Summary
- cover enum parsing helpers
- add ResultExtensions tests for ping timings and HTTP response parsing

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684ee26f1b54832e8af5d95f836781e8