### PR TITLE
Exclude examples from coverage

### DIFF
--- a/Globalping.Examples/Properties/AssemblyInfo.cs
+++ b/Globalping.Examples/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]
+


### PR DESCRIPTION
## Summary
- mark the Globalping.Examples assembly so Coverlet ignores it when generating code coverage

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj -c Release --verbosity quiet --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_684eed60641c832ea97e06fcc71c28bc