### PR TITLE
Fix MeasurementType serialization

### DIFF
--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -166,4 +166,17 @@ public sealed class MeasurementRequestTests
         var options = Assert.IsType<PingOptions>(request.MeasurementOptions);
         Assert.Equal(4, options.Packets);
     }
+
+    [Fact]
+    public void BuilderSerializesTypeInCamelCase()
+    {
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .Build();
+
+        var json = JsonSerializer.Serialize(request, JsonOptions);
+
+        Assert.Contains("\"type\":\"ping\"", json);
+    }
 }

--- a/Globalping/Enums/MeasurementType.cs
+++ b/Globalping/Enums/MeasurementType.cs
@@ -1,7 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MeasurementType {
     Ping,
     Traceroute,


### PR DESCRIPTION
## Summary
- remove built-in enum converter from `MeasurementType`
- test that a measurement request serializes enums using camelCase

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684eef7fe5b8832e822c0ff10fcf4769