### PR TITLE
Capture Retry-After header

### DIFF
--- a/Globalping.Tests/UsageHeaderTests.cs
+++ b/Globalping.Tests/UsageHeaderTests.cs
@@ -38,6 +38,7 @@ public class UsageHeaderTests
         response.Headers.Add("X-Credits-Consumed", "2");
         response.Headers.Add("X-Credits-Remaining", "8");
         response.Headers.Add("X-Request-Cost", "2");
+        response.Headers.Add("Retry-After", "15");
         response.Headers.ETag = new EntityTagHeaderValue("\"abc\"");
 
         var client = new HttpClient(new MockHandler(response));
@@ -52,6 +53,7 @@ public class UsageHeaderTests
         Assert.Equal(8, service.LastResponseInfo.CreditsRemaining);
         Assert.Equal(2, service.LastResponseInfo.RequestCost);
         Assert.Equal("\"abc\"", service.LastResponseInfo.ETag);
+        Assert.Equal(15, service.LastResponseInfo.RetryAfter);
     }
 
     [Fact]
@@ -69,6 +71,7 @@ public class UsageHeaderTests
         response.Headers.Add("X-Credits-Consumed", "3");
         response.Headers.Add("X-Credits-Remaining", "7");
         response.Headers.Add("X-Request-Cost", "1");
+        response.Headers.Add("Retry-After", "25");
         response.Headers.ETag = new EntityTagHeaderValue("\"def\"");
 
         var client = new HttpClient(new MockHandler(response));
@@ -83,5 +86,6 @@ public class UsageHeaderTests
         Assert.Equal(7, measurementClient.LastResponseInfo.CreditsRemaining);
         Assert.Equal(1, measurementClient.LastResponseInfo.RequestCost);
         Assert.Equal("\"def\"", measurementClient.LastResponseInfo.ETag);
+        Assert.Equal(25, measurementClient.LastResponseInfo.RetryAfter);
     }
 }

--- a/Globalping/ApiUsageInfo.cs
+++ b/Globalping/ApiUsageInfo.cs
@@ -14,5 +14,6 @@ public class ApiUsageInfo
     public int? CreditsConsumed { get; set; }
     public int? CreditsRemaining { get; set; }
     public int? RequestCost { get; set; }
+    public int? RetryAfter { get; set; }
     public string? ETag { get; set; }
 }

--- a/Globalping/MeasurementClient.cs
+++ b/Globalping/MeasurementClient.cs
@@ -64,6 +64,7 @@ public class MeasurementClient {
             CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
             CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
             RequestCost = TryGetInt(headers, "X-Request-Cost"),
+            RetryAfter = TryGetInt(headers, "Retry-After"),
             ETag = headers.ETag?.Tag
         };
     }

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -68,6 +68,7 @@ public class ProbeService {
             CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
             CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
             RequestCost = TryGetInt(headers, "X-Request-Cost"),
+            RetryAfter = TryGetInt(headers, "Retry-After"),
             ETag = headers.ETag?.Tag
         };
     }


### PR DESCRIPTION
## Summary
- expose `RetryAfter` in `ApiUsageInfo`
- parse `Retry-After` header in `ProbeService` and `MeasurementClient`
- test capturing `Retry-After` header

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684eef7d6864832eb4084d4e6cf99e28