### PR TITLE
Introduce RateLimitType enum for rate limit handling

### DIFF
--- a/Globalping.Tests/AdditionalCoverageTests.cs
+++ b/Globalping.Tests/AdditionalCoverageTests.cs
@@ -215,11 +215,11 @@ public class AdditionalCoverageTests
             {
                 ["measurements"] = new Dictionary<string, RateLimitDetails>
                 {
-                    ["create"] = new RateLimitDetails { Type = "ip", Limit = 10, Remaining = 9, Reset = 100 }
+                    ["create"] = new RateLimitDetails { Type = RateLimitType.Ip, Limit = 10, Remaining = 9, Reset = 100 }
                 },
                 ["probes"] = new Dictionary<string, RateLimitDetails>
                 {
-                    ["list"] = new RateLimitDetails { Type = "ip", Limit = 5, Remaining = 4, Reset = 200 }
+                    ["list"] = new RateLimitDetails { Type = RateLimitType.Ip, Limit = 5, Remaining = 4, Reset = 200 }
                 }
             }
         };

--- a/Globalping.Tests/LimitsDeserializationTests.cs
+++ b/Globalping.Tests/LimitsDeserializationTests.cs
@@ -24,7 +24,7 @@ public sealed class LimitsDeserializationTests
         var measurements = limits.RateLimit["measurements"];
         Assert.True(measurements.ContainsKey("create"));
         var create = measurements["create"];
-        Assert.Equal("ip", create.Type);
+        Assert.Equal(RateLimitType.Ip, create.Type);
         Assert.Equal(10, create.Limit);
         Assert.Equal(8, create.Remaining);
         Assert.Equal(1000, create.Reset);

--- a/Globalping/Enums/RateLimitType.cs
+++ b/Globalping/Enums/RateLimitType.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+/// <summary>
+/// Specifies the type of rate limit applied by the API.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum RateLimitType
+{
+    /// <summary>
+    /// Rate limit that applies per IP address.
+    /// </summary>
+    Ip,
+
+    /// <summary>
+    /// Rate limit that applies per authenticated user.
+    /// </summary>
+    User
+}

--- a/Globalping/LimitsExtensions.cs
+++ b/Globalping/LimitsExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace Globalping;
 
@@ -24,7 +25,7 @@ public static class LimitsExtensions
                 {
                     Category = category.Key,
                     Action = action.Key,
-                    Type = detail.Type,
+                    Type = JsonNamingPolicy.CamelCase.ConvertName(detail.Type.ToString()),
                     Limit = detail.Limit,
                     Remaining = detail.Remaining,
                     Reset = detail.Reset,

--- a/Globalping/Models/RateLimitDetails.cs
+++ b/Globalping/Models/RateLimitDetails.cs
@@ -11,7 +11,7 @@ public class RateLimitDetails
     /// Kind of limit applied by the API, typically <c>ip</c> or <c>user</c>.
     /// </summary>
     [JsonPropertyName("type")]
-    public string Type { get; set; } = string.Empty;
+    public RateLimitType Type { get; set; }
 
     /// <summary>
     /// Maximum number of allowed actions within the window.


### PR DESCRIPTION
## Summary
- add `RateLimitType` enum with camel-case JSON conversion
- switch `RateLimitDetails.Type` to use the new enum
- convert rate limit type to camel-case string when flattening
- update unit tests for enum usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684eefaa31c4832eb4997df32cf06c6b