### PR TITLE
Fix probe tag display

### DIFF
--- a/Globalping.PowerShell/GetGlobalpingProbeCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingProbeCommand.cs
@@ -13,7 +13,7 @@ namespace Globalping.PowerShell;
 ///   <para>Outputs flattened probe objects describing each online probe.</para>
 /// </example>
 [Cmdlet(VerbsCommon.Get, "GlobalpingProbe")]
-[OutputType(typeof(Probe))]
+[OutputType(typeof(ProbeInfo))]
 [OutputType(typeof(Probes))]
 public class GetGlobalpingProbeCommand : PSCmdlet {
     /// <summary>API key used for authenticated calls.</summary>
@@ -46,23 +46,7 @@ public class GetGlobalpingProbeCommand : PSCmdlet {
 
         foreach (var p in probes)
         {
-            var loc = p.Location;
-            var probe = new Probe
-            {
-                Continent = loc?.Continent ?? string.Empty,
-                Region = loc?.Region ?? string.Empty,
-                Country = loc?.Country ?? string.Empty,
-                State = loc?.State ?? string.Empty,
-                City = loc?.City ?? string.Empty,
-                Asn = loc?.Asn ?? 0,
-                Longitude = loc?.Longitude ?? 0,
-                Latitude = loc?.Latitude ?? 0,
-                Network = loc?.Network ?? string.Empty,
-                Tags = p.Tags ?? new List<string>(),
-                Resolvers = p.Resolvers ?? new List<string>(),
-                Version = p.Version
-            };
-            WriteObject(probe);
+            WriteObject(p.ToProbeInfo());
         }
     }
 }

--- a/Globalping.Tests/ProbeInfoTests.cs
+++ b/Globalping.Tests/ProbeInfoTests.cs
@@ -6,12 +6,13 @@ namespace Globalping.Tests;
 public class ProbeInfoTests
 {
     [Fact]
-    public void ToProbeInfo_ConvertsValues()
+    public void ToProbeInfo_HandlesTagAndResolverConversion()
     {
-        const string json = "{\"version\":\"1.0\",\"location\":{\"continent\":\"SA\",\"region\":\"South America\",\"country\":\"BR\",\"state\":\"SP\",\"city\":\"Sao Paulo\",\"asn\":31898,\"longitude\":-46.64,\"latitude\":-23.55,\"network\":\"Oracle Corporation\"},\"tags\":[\"datacenter-network\"]}";
+        const string json = "{\"version\":\"1.0\",\"location\":{\"continent\":\"SA\",\"region\":\"South America\",\"country\":\"BR\",\"state\":\"SP\",\"city\":\"Sao Paulo\",\"asn\":31898,\"longitude\":-46.64,\"latitude\":-23.55,\"network\":\"Oracle Corporation\"},\"tags\":[\"datacenter-network\"],\"resolvers\":[\"1.1.1.1\"]}";
         var probe = JsonSerializer.Deserialize<Probes>(json);
         Assert.NotNull(probe);
         var info = probe!.ToProbeInfo();
+
         Assert.Equal("SA", info.Continent);
         Assert.Equal("South America", info.Region);
         Assert.Equal("BR", info.Country);
@@ -21,7 +22,40 @@ public class ProbeInfoTests
         Assert.Equal(-46.64, info.Longitude);
         Assert.Equal(-23.55, info.Latitude);
         Assert.Equal("Oracle Corporation", info.Network);
-        Assert.Equal("datacenter-network", info.Tags);
+
+        var tag = Assert.IsType<string>(info.Tags);
+        Assert.Equal("datacenter-network", tag);
+
+        var resolver = Assert.IsType<string>(info.Resolvers);
+        Assert.Equal("1.1.1.1", resolver);
+
         Assert.Equal("1.0", info.Version);
+    }
+
+    [Fact]
+    public void ToProbeInfo_HandlesMultipleTags()
+    {
+        const string json = "{\"version\":\"1\",\"location\":{},\"tags\":[\"a\",\"b\"],\"resolvers\":[\"8.8.8.8\",\"8.8.4.4\"]}";
+        var probe = JsonSerializer.Deserialize<Probes>(json);
+        Assert.NotNull(probe);
+        var info = probe!.ToProbeInfo();
+
+        var tags = Assert.IsType<string[]>(info.Tags);
+        Assert.Equal(new[] { "a", "b" }, tags);
+
+        var resolvers = Assert.IsType<string[]>(info.Resolvers);
+        Assert.Equal(new[] { "8.8.8.8", "8.8.4.4" }, resolvers);
+    }
+
+    [Fact]
+    public void ToProbeInfo_HandlesEmptyLists()
+    {
+        const string json = "{\"version\":\"1\",\"location\":{},\"tags\":[],\"resolvers\":[]}";
+        var probe = JsonSerializer.Deserialize<Probes>(json);
+        Assert.NotNull(probe);
+        var info = probe!.ToProbeInfo();
+
+        Assert.Null(info.Tags);
+        Assert.Null(info.Resolvers);
     }
 }

--- a/Globalping.Tests/ProbeInfoTests.cs
+++ b/Globalping.Tests/ProbeInfoTests.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ProbeInfoTests
+{
+    [Fact]
+    public void ToProbeInfo_ConvertsValues()
+    {
+        const string json = "{\"version\":\"1.0\",\"location\":{\"continent\":\"SA\",\"region\":\"South America\",\"country\":\"BR\",\"state\":\"SP\",\"city\":\"Sao Paulo\",\"asn\":31898,\"longitude\":-46.64,\"latitude\":-23.55,\"network\":\"Oracle Corporation\"},\"tags\":[\"datacenter-network\"]}";
+        var probe = JsonSerializer.Deserialize<Probes>(json);
+        Assert.NotNull(probe);
+        var info = probe!.ToProbeInfo();
+        Assert.Equal("SA", info.Continent);
+        Assert.Equal("South America", info.Region);
+        Assert.Equal("BR", info.Country);
+        Assert.Equal("SP", info.State);
+        Assert.Equal("Sao Paulo", info.City);
+        Assert.Equal(31898, info.Asn);
+        Assert.Equal(-46.64, info.Longitude);
+        Assert.Equal(-23.55, info.Latitude);
+        Assert.Equal("Oracle Corporation", info.Network);
+        Assert.Equal("datacenter-network", info.Tags);
+        Assert.Equal("1.0", info.Version);
+    }
+}

--- a/Globalping/ProbeExtensions.cs
+++ b/Globalping/ProbeExtensions.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace Globalping;
+
+/// <summary>
+/// Extension helpers for <see cref="Probes"/>.
+/// </summary>
+public static class ProbeExtensions
+{
+    /// <summary>Converts a <see cref="Probes"/> object into <see cref="ProbeInfo"/>.</summary>
+    /// <param name="probe">Raw probe information.</param>
+    /// <returns>Flattened probe data.</returns>
+    public static ProbeInfo ToProbeInfo(this Probes probe)
+    {
+        var loc = probe.Location;
+        return new ProbeInfo
+        {
+            Continent = loc?.Continent ?? string.Empty,
+            Region = loc?.Region ?? string.Empty,
+            Country = loc?.Country ?? string.Empty,
+            State = loc?.State ?? string.Empty,
+            City = loc?.City ?? string.Empty,
+            Asn = loc?.Asn ?? 0,
+            Longitude = loc?.Longitude ?? 0,
+            Latitude = loc?.Latitude ?? 0,
+            Network = loc?.Network ?? string.Empty,
+            Tags = probe.Tags is null ? string.Empty : string.Join(", ", probe.Tags),
+            Version = probe.Version
+        };
+    }
+}

--- a/Globalping/ProbeExtensions.cs
+++ b/Globalping/ProbeExtensions.cs
@@ -24,8 +24,24 @@ public static class ProbeExtensions
             Longitude = loc?.Longitude ?? 0,
             Latitude = loc?.Latitude ?? 0,
             Network = loc?.Network ?? string.Empty,
-            Tags = probe.Tags is null ? string.Empty : string.Join(", ", probe.Tags),
+            Tags = ConvertList(probe.Tags),
+            Resolvers = ConvertList(probe.Resolvers),
             Version = probe.Version
         };
+    }
+
+    private static object? ConvertList(List<string>? items)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return null;
+        }
+
+        if (items.Count == 1)
+        {
+            return items[0];
+        }
+
+        return items.ToArray();
     }
 }

--- a/Globalping/ProbeInfo.cs
+++ b/Globalping/ProbeInfo.cs
@@ -32,8 +32,11 @@ public class ProbeInfo
     /// <summary>Network provider.</summary>
     public string Network { get; set; } = string.Empty;
 
-    /// <summary>Comma separated list of probe tags.</summary>
-    public string Tags { get; set; } = string.Empty;
+    /// <summary>Tags associated with the probe. Can be a string, array or <c>null</c>.</summary>
+    public object? Tags { get; set; }
+
+    /// <summary>DNS resolvers used by the probe. Can be a string, array or <c>null</c>.</summary>
+    public object? Resolvers { get; set; }
 
     /// <summary>Probe software version.</summary>
     public string Version { get; set; } = string.Empty;

--- a/Globalping/ProbeInfo.cs
+++ b/Globalping/ProbeInfo.cs
@@ -1,0 +1,40 @@
+namespace Globalping;
+
+/// <summary>
+/// Provides a flattened view of probe information.
+/// </summary>
+public class ProbeInfo
+{
+    /// <summary>Continent where the probe is located.</summary>
+    public string Continent { get; set; } = string.Empty;
+
+    /// <summary>Region of the probe location.</summary>
+    public string Region { get; set; } = string.Empty;
+
+    /// <summary>Country ISO code.</summary>
+    public string Country { get; set; } = string.Empty;
+
+    /// <summary>Administrative subdivision.</summary>
+    public string State { get; set; } = string.Empty;
+
+    /// <summary>City name.</summary>
+    public string City { get; set; } = string.Empty;
+
+    /// <summary>Autonomous system number.</summary>
+    public int Asn { get; set; }
+
+    /// <summary>Probe longitude.</summary>
+    public double Longitude { get; set; }
+
+    /// <summary>Probe latitude.</summary>
+    public double Latitude { get; set; }
+
+    /// <summary>Network provider.</summary>
+    public string Network { get; set; } = string.Empty;
+
+    /// <summary>Comma separated list of probe tags.</summary>
+    public string Tags { get; set; } = string.Empty;
+
+    /// <summary>Probe software version.</summary>
+    public string Version { get; set; } = string.Empty;
+}

--- a/Module/Examples/Example-Probes.ps1
+++ b/Module/Examples/Example-Probes.ps1
@@ -1,7 +1,7 @@
 Import-Module $PSScriptRoot\..\Globalping.psd1 -Force
 
 # Display flattened probe information
-Get-GlobalpingProbe | Select-Object -First 5 | Format-Table
+Get-GlobalpingProbe | Select-Object -First 5 | Format-Table *
 
 # Retrieve the raw probe objects
-Get-GlobalpingProbe -Raw | Select-Object -First 5 | Format-Table
+Get-GlobalpingProbe -Raw | Select-Object -First 5 | Format-Table *


### PR DESCRIPTION
## Summary
- flatten probe info for friendly display
- expose ToProbeInfo extension method
- update Get-GlobalpingProbe output
- cover new behaviour with tests

## Testing
- `dotnet test`
- `Invoke-Pester` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef3bfe0e8832e9087d059fe6a2567