### PR TITLE
Add Globalping.Mobile MAUI sample

### DIFF
--- a/Globalping.Mobile/App.xaml
+++ b/Globalping.Mobile/App.xaml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             x:Class="Globalping.Mobile.App">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/Globalping.Mobile/App.xaml.cs
+++ b/Globalping.Mobile/App.xaml.cs
@@ -1,0 +1,11 @@
+namespace Globalping.Mobile;
+
+public partial class App : Application
+{
+    public App()
+    {
+        InitializeComponent();
+
+        MainPage = new MainPage();
+    }
+}

--- a/Globalping.Mobile/Globalping.Mobile.csproj
+++ b/Globalping.Mobile/Globalping.Mobile.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationTitle>Globalping Mobile</ApplicationTitle>
+    <ApplicationId>com.evotec.globalpingmobile</ApplicationId>
+    <RootNamespace>Globalping.Mobile</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Globalping\Globalping.csproj" />
+  </ItemGroup>
+</Project>

--- a/Globalping.Mobile/MainPage.xaml
+++ b/Globalping.Mobile/MainPage.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Globalping.Mobile.MainPage">
+    <VerticalStackLayout Spacing="10" Padding="20">
+        <Label Text="Globalping Mobile Sample" FontAttributes="Bold" FontSize="18" />
+        <Entry x:Name="HostEntry" Placeholder="Enter host" />
+        <Picker x:Name="TypePicker" Title="Measurement Type">
+            <Picker.Items>
+                <x:String>Ping</x:String>
+                <x:String>HTTP</x:String>
+            </Picker.Items>
+        </Picker>
+        <Button Text="Run" Clicked="OnRunClicked" />
+        <ScrollView>
+            <Label x:Name="ResultLabel" LineBreakMode="CharacterWrap" />
+        </ScrollView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/Globalping.Mobile/MainPage.xaml.cs
+++ b/Globalping.Mobile/MainPage.xaml.cs
@@ -1,0 +1,46 @@
+using Globalping;
+using System;
+using System.Net.Http;
+using System.Net;
+
+namespace Globalping.Mobile;
+
+public partial class MainPage : ContentPage
+{
+    public MainPage()
+    {
+        InitializeComponent();
+        TypePicker.SelectedIndex = 0;
+    }
+
+    private async void OnRunClicked(object sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(HostEntry.Text))
+        {
+            await DisplayAlert("Error", "Please enter a host", "OK");
+            return;
+        }
+
+        var measurementType = TypePicker.SelectedIndex == 0 ? MeasurementType.Ping : MeasurementType.Http;
+
+        var request = new MeasurementRequestBuilder()
+            .WithType(measurementType)
+            .WithTarget(HostEntry.Text)
+            .Build();
+
+        using var httpClient = new HttpClient(new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.All
+        });
+
+        var probeService = new ProbeService(httpClient);
+        var measurement = await probeService.CreateMeasurementAsync(request);
+
+        var client = new MeasurementClient(httpClient);
+        var result = await client.GetMeasurementByIdAsync(measurement.Id);
+
+        ResultLabel.Text = result != null
+            ? System.Text.Json.JsonSerializer.Serialize(result, new System.Text.Json.JsonSerializerOptions { WriteIndented = true })
+            : "No result";
+    }
+}

--- a/Globalping.Mobile/MauiProgram.cs
+++ b/Globalping.Mobile/MauiProgram.cs
@@ -1,0 +1,13 @@
+namespace Globalping.Mobile;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>();
+
+        return builder.Build();
+    }
+}

--- a/Globalping.Mobile/Platforms/Android/MainActivity.cs
+++ b/Globalping.Mobile/Platforms/Android/MainActivity.cs
@@ -1,0 +1,12 @@
+using Android.App;
+using Android.Content.PM;
+using Android.OS;
+
+namespace Globalping.Mobile;
+
+[Activity(Label = "Globalping Mobile", Theme = "@style/Maui.SplashTheme", MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
+    ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize)]
+public class MainActivity : MauiAppCompatActivity
+{
+}

--- a/Globalping.Mobile/Platforms/Android/MainApplication.cs
+++ b/Globalping.Mobile/Platforms/Android/MainApplication.cs
@@ -1,0 +1,15 @@
+using Android.App;
+using Android.Runtime;
+
+namespace Globalping.Mobile;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/Globalping.Mobile/Platforms/iOS/AppDelegate.cs
+++ b/Globalping.Mobile/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,9 @@
+using Foundation;
+
+namespace Globalping.Mobile;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/Globalping.Mobile/Platforms/iOS/Program.cs
+++ b/Globalping.Mobile/Platforms/iOS/Program.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace Globalping.Mobile;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/Globalping.sln
+++ b/Globalping.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Globalping.PowerShell", "Gl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Globalping.Tests", "Globalping.Tests\Globalping.Tests.csproj", "{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Globalping.Mobile", "Globalping.Mobile\Globalping.Mobile.csproj", "{286B50D2-1816-48B1-BFA8-2D7BDA4FF0B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Release|Any CPU.Build.0 = Release|Any CPU
+		{286B50D2-1816-48B1-BFA8-2D7BDA4FF0B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{286B50D2-1816-48B1-BFA8-2D7BDA4FF0B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{286B50D2-1816-48B1-BFA8-2D7BDA4FF0B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{286B50D2-1816-48B1-BFA8-2D7BDA4FF0B1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.MD
+++ b/README.MD
@@ -195,3 +195,18 @@ property. When the service returns values such as `X-RateLimit-Limit` or
 value to `GetMeasurementByIdAsync` or `GetMeasurementById`. When the API returns
 `304 Not Modified` the previously retrieved measurement data is reused and parsing
 is skipped.
+
+## Mobile Usage
+
+A minimal .NET MAUI sample is provided in the `Globalping.Mobile` project. It works on Android and iOS and demonstrates how to trigger ping or HTTP measurements using the library.
+
+### Build and run
+
+1. Install the .NET mobile workloads for Android and iOS (`dotnet workload install maui-android maui-ios`).
+2. Open `Globalping.sln` in Visual Studio 2022 or run the project from the command line:
+   ```bash
+   dotnet build Globalping.Mobile/Globalping.Mobile.csproj -t:Run -f net8.0-android
+   ```
+   Replace `net8.0-android` with `net8.0-ios` to run on iOS.
+
+Enter a host, choose the measurement type and press **Run** to execute the request. The returned measurement result is shown in the app.


### PR DESCRIPTION
## Summary
- add new `Globalping.Mobile` project for Android & iOS
- connect sample UI to `MeasurementClient`
- document how to build and run the mobile sample

## Testing
- `dotnet restore Globalping.sln`
- `dotnet build Globalping.sln --configuration Release --no-restore`
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --configuration Release --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684f2ad4b154832e8ab9dd2bb2383664