### PR TITLE
Support multiple measurement targets

### DIFF
--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Globalping Cmdlets" {
     }
 
     It "Start-GlobalpingPing returns output" {
-        $results = Start-GlobalpingPing -Target "evotec.xyz" -Limit 1 -ErrorAction Stop
+        $results = Start-GlobalpingPing -Target "evotec.xyz","example.com" -Limit 1 -ErrorAction Stop
         $results | Should -Not -BeNullOrEmpty
     }
 


### PR DESCRIPTION
## Summary
- support multiple targets in measurement cmdlets
- test ping command with two targets

## Testing
- `dotnet build Globalping.sln --configuration Debug --no-restore`
- `pwsh ./Module/Globalping.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68517ca8bcd0832ea2f8953b77ae084e