### PR TITLE
Add XML docs for models and enums

### DIFF
--- a/Globalping/Enums/ContinentCode.cs
+++ b/Globalping/Enums/ContinentCode.cs
@@ -3,15 +3,31 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// ISO continent codes used in location information.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ContinentCode
 {
+    /// <summary>Africa.</summary>
     AF,
+
+    /// <summary>Antarctica.</summary>
     AN,
+
+    /// <summary>Asia.</summary>
     AS,
+
+    /// <summary>Europe.</summary>
     EU,
+
+    /// <summary>North America.</summary>
     NA,
+
+    /// <summary>Oceania.</summary>
     OC,
+
+    /// <summary>South America.</summary>
     SA
 }
 

--- a/Globalping/Enums/DnsProtocol.cs
+++ b/Globalping/Enums/DnsProtocol.cs
@@ -2,9 +2,15 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Available protocols for DNS queries.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DnsProtocol
 {
+    /// <summary>Transmission Control Protocol.</summary>
     TCP,
+
+    /// <summary>User Datagram Protocol.</summary>
     UDP
 }

--- a/Globalping/Enums/DnsQueryType.cs
+++ b/Globalping/Enums/DnsQueryType.cs
@@ -1,21 +1,55 @@
 namespace Globalping;
 
+/// <summary>
+/// Common DNS record types that can be queried.
+/// </summary>
 public enum DnsQueryType
 {
+    /// <summary>IPv4 host address record.</summary>
     A,
+
+    /// <summary>IPv6 host address record.</summary>
     AAAA,
+
+    /// <summary>Wildcard query for all records.</summary>
     ANY,
+
+    /// <summary>Canonical name record.</summary>
     CNAME,
+
+    /// <summary>DNSKEY record.</summary>
     DNSKEY,
+
+    /// <summary>Delegation signer record.</summary>
     DS,
+
+    /// <summary>HTTPS service binding.</summary>
     HTTPS,
+
+    /// <summary>Mail exchanger record.</summary>
     MX,
+
+    /// <summary>Name server record.</summary>
     NS,
+
+    /// <summary>NSEC record.</summary>
     NSEC,
+
+    /// <summary>Pointer record.</summary>
     PTR,
+
+    /// <summary>Resource record signature.</summary>
     RRSIG,
+
+    /// <summary>Start of authority record.</summary>
     SOA,
+
+    /// <summary>Text record.</summary>
     TXT,
+
+    /// <summary>Service locator.</summary>
     SRV,
+
+    /// <summary>Service binding.</summary>
     SVCB
 }

--- a/Globalping/Enums/HttpProtocol.cs
+++ b/Globalping/Enums/HttpProtocol.cs
@@ -2,10 +2,18 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// HTTP protocol versions that can be used when performing HTTP measurements.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum HttpProtocol
 {
+    /// <summary>Classic HTTP/1.x.</summary>
     HTTP,
+
+    /// <summary>Secure HTTP over TLS.</summary>
     HTTPS,
+
+    /// <summary>HTTP/2.</summary>
     HTTP2
 }

--- a/Globalping/Enums/HttpRequestMethod.cs
+++ b/Globalping/Enums/HttpRequestMethod.cs
@@ -2,10 +2,18 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// HTTP methods supported by the Globalping service.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum HttpRequestMethod
 {
+    /// <summary>HEAD request.</summary>
     HEAD,
+
+    /// <summary>GET request.</summary>
     GET,
+
+    /// <summary>OPTIONS request.</summary>
     OPTIONS
 }

--- a/Globalping/Enums/IpVersion.cs
+++ b/Globalping/Enums/IpVersion.cs
@@ -2,9 +2,15 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// IP protocol versions supported by the API.
+/// </summary>
 [JsonConverter(typeof(IpVersionConverter))]
 public enum IpVersion
 {
+    /// <summary>IPv4.</summary>
     Four = 4,
+
+    /// <summary>IPv6.</summary>
     Six = 6
 }

--- a/Globalping/Enums/MeasurementStatus.cs
+++ b/Globalping/Enums/MeasurementStatus.cs
@@ -2,8 +2,14 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Current processing state of a measurement.
+/// </summary>
 public enum MeasurementStatus
 {
+    /// <summary>Measurement is still running.</summary>
     InProgress,
+
+    /// <summary>Measurement has completed.</summary>
     Finished
 }

--- a/Globalping/Enums/MeasurementType.cs
+++ b/Globalping/Enums/MeasurementType.cs
@@ -1,10 +1,22 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Supported measurement types that can be executed on a probe.
+/// </summary>
 public enum MeasurementType {
+    /// <summary>ICMP ping measurement.</summary>
     Ping,
+
+    /// <summary>Traceroute measurement.</summary>
     Traceroute,
+
+    /// <summary>DNS lookup measurement.</summary>
     Dns,
+
+    /// <summary>My traceroute measurement.</summary>
     Mtr,
+
+    /// <summary>HTTP request measurement.</summary>
     Http
 }

--- a/Globalping/Enums/MtrProtocol.cs
+++ b/Globalping/Enums/MtrProtocol.cs
@@ -2,10 +2,18 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Transport protocols for the MTR measurement.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MtrProtocol
 {
+    /// <summary>ICMP protocol.</summary>
     ICMP,
+
+    /// <summary>TCP protocol.</summary>
     TCP,
+
+    /// <summary>UDP protocol.</summary>
     UDP
 }

--- a/Globalping/Enums/RegionName.cs
+++ b/Globalping/Enums/RegionName.cs
@@ -6,6 +6,9 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Geographical regions used for locating probes.
+/// </summary>
 [JsonConverter(typeof(RegionNameConverter))]
 public enum RegionName
 {

--- a/Globalping/Enums/TlsKeyType.cs
+++ b/Globalping/Enums/TlsKeyType.cs
@@ -2,9 +2,15 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Public key algorithms used by TLS certificates.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TlsKeyType
 {
+    /// <summary>RSA key.</summary>
     RSA,
+
+    /// <summary>Elliptic curve key.</summary>
     EC
 }

--- a/Globalping/Enums/TracerouteProtocol.cs
+++ b/Globalping/Enums/TracerouteProtocol.cs
@@ -2,10 +2,18 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Network protocols that can be used for traceroute operations.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TracerouteProtocol
 {
+    /// <summary>ICMP traceroute.</summary>
     ICMP,
+
+    /// <summary>TCP traceroute.</summary>
     TCP,
+
+    /// <summary>UDP traceroute.</summary>
     UDP
 }

--- a/Globalping/Models/CreateMeasurementResponse.cs
+++ b/Globalping/Models/CreateMeasurementResponse.cs
@@ -2,10 +2,15 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Response returned after creating a measurement request.
+/// </summary>
 public class CreateMeasurementResponse {
+    /// <summary>Identifier of the newly created measurement.</summary>
     [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
+    /// <summary>Number of probes involved in the measurement.</summary>
     [JsonPropertyName("probesCount")]
     public int ProbesCount { get; set; }
 }

--- a/Globalping/Models/DnsOptions.cs
+++ b/Globalping/Models/DnsOptions.cs
@@ -1,22 +1,31 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Options controlling a DNS measurement.
+/// </summary>
 public class DnsOptions : IMeasurementOptions {
+    /// <summary>Query parameters for the DNS request.</summary>
     [JsonPropertyName("query")]
     public DnsQuery Query { get; set; } = new DnsQuery();
 
+    /// <summary>Resolver hostname or IP address.</summary>
     [JsonPropertyName("resolver")]
     public string? Resolver { get; set; } // Can be IPv4, IPv6, or hostname
 
+    /// <summary>Network port used by the DNS server.</summary>
     [JsonPropertyName("port")]
     public int Port { get; set; } = 53;
 
+    /// <summary>Transport protocol for the query.</summary>
     [JsonPropertyName("protocol")]
     public DnsProtocol Protocol { get; set; } = DnsProtocol.UDP;
 
+    /// <summary>Preferred IP protocol version.</summary>
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;
 
+    /// <summary>Whether to perform a DNS trace.</summary>
     [JsonPropertyName("trace")]
     public bool Trace { get; set; } = false;
 }

--- a/Globalping/Models/DnsQuery.cs
+++ b/Globalping/Models/DnsQuery.cs
@@ -1,7 +1,11 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Describes the DNS record to query.
+/// </summary>
 public class DnsQuery {
+    /// <summary>Type of DNS record to request.</summary>
     [JsonPropertyName("type")]
     public DnsQueryType Type { get; set; } = DnsQueryType.A;
 }

--- a/Globalping/Models/HttpOptions.cs
+++ b/Globalping/Models/HttpOptions.cs
@@ -2,20 +2,27 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
-
+/// <summary>
+/// Options that configure an HTTP measurement.
+/// </summary>
 public class HttpOptions : IMeasurementOptions {
+    /// <summary>Details of the HTTP request to perform.</summary>
     [JsonPropertyName("request")]
     public HttpRequestOptions Request { get; set; } = new HttpRequestOptions();
 
+    /// <summary>Optional resolver to use for DNS lookups.</summary>
     [JsonPropertyName("resolver")]
     public string? Resolver { get; set; }
 
+    /// <summary>Target port for the request.</summary>
     [JsonPropertyName("port")]
     public int Port { get; set; } = 80;
 
+    /// <summary>HTTP protocol version to use.</summary>
     [JsonPropertyName("protocol")]
     public HttpProtocol Protocol { get; set; } = HttpProtocol.HTTPS;
 
+    /// <summary>Preferred IP version when resolving the target.</summary>
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;
 }

--- a/Globalping/Models/HttpRequestOptions.cs
+++ b/Globalping/Models/HttpRequestOptions.cs
@@ -4,20 +4,28 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Describes the HTTP request issued by the measurement.
+/// </summary>
 public class HttpRequestOptions
 {
+    /// <summary>Hostname used for the request.</summary>
     [JsonPropertyName("host")]
     public string? Host { get; set; }
 
+    /// <summary>Request path.</summary>
     [JsonPropertyName("path")]
     public string? Path { get; set; }
 
+    /// <summary>Query string portion of the request.</summary>
     [JsonPropertyName("query")]
     public string? Query { get; set; }
 
+    /// <summary>HTTP method to use.</summary>
     [JsonPropertyName("method")]
     public HttpRequestMethod Method { get; set; } = HttpRequestMethod.HEAD;
 
+    /// <summary>Optional HTTP headers to include.</summary>
     [JsonPropertyName("headers")]
     public Dictionary<string, string> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/Globalping/Models/IMeasurementOptions.cs
+++ b/Globalping/Models/IMeasurementOptions.cs
@@ -1,3 +1,6 @@
-﻿namespace Globalping;
+namespace Globalping;
 
+/// <summary>
+/// Marker interface for measurement option classes.
+/// </summary>
 public interface IMeasurementOptions { }

--- a/Globalping/Models/Location.cs
+++ b/Globalping/Models/Location.cs
@@ -1,31 +1,43 @@
 using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Represents geographical information for a probe.
+/// </summary>
 public class Location {
+    /// <summary>Continent in which the probe resides.</summary>
     [JsonPropertyName("continent")]
     public string Continent { get; set; } = string.Empty;
 
+    /// <summary>Region such as a world sub-region or state.</summary>
     [JsonPropertyName("region")]
     public string Region { get; set; } = string.Empty;
 
+    /// <summary>Country name.</summary>
     [JsonPropertyName("country")]
     public string Country { get; set; } = string.Empty;
 
+    /// <summary>State or province.</summary>
     [JsonPropertyName("state")]
     public string State { get; set; } = string.Empty;
 
+    /// <summary>City name.</summary>
     [JsonPropertyName("city")]
     public string City { get; set; } = string.Empty;
 
+    /// <summary>Autonomous system number.</summary>
     [JsonPropertyName("asn")]
     public int Asn { get; set; }
 
+    /// <summary>Provider network name.</summary>
     [JsonPropertyName("network")]
     public string Network { get; set; } = string.Empty;
 
+    /// <summary>Latitude coordinate.</summary>
     [JsonPropertyName("latitude")]
     public double Latitude { get; set; }
 
+    /// <summary>Longitude coordinate.</summary>
     [JsonPropertyName("longitude")]
     public double Longitude { get; set; }
 }

--- a/Globalping/Models/LocationRequest.cs
+++ b/Globalping/Models/LocationRequest.cs
@@ -3,34 +3,47 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Parameters used to select probes by location.
+/// </summary>
 public class LocationRequest {
+    /// <summary>Desired continent for the probe.</summary>
     [JsonPropertyName("continent")]
     public ContinentCode? Continent { get; set; }
 
+    /// <summary>Specific region within the continent.</summary>
     [JsonPropertyName("region")]
     public RegionName? Region { get; set; }
 
+    /// <summary>ISO country name.</summary>
     [JsonPropertyName("country")]
     public string? Country { get; set; }
 
+    /// <summary>State or province within the country.</summary>
     [JsonPropertyName("state")]
     public string? State { get; set; }
 
+    /// <summary>City name.</summary>
     [JsonPropertyName("city")]
     public string? City { get; set; }
 
+    /// <summary>Maximum number of probes to use.</summary>
     [JsonPropertyName("limit")]
     public int? Limit { get; set; } // Optional limit for probes
 
+    /// <summary>Optional "magic" location identifier.</summary>
     [JsonPropertyName("magic")]
     public string? Magic { get; set; } // For "magic" location requests
 
+    /// <summary>Filter by autonomous system number.</summary>
     [JsonPropertyName("asn")]
     public int? Asn { get; set; }
 
+    /// <summary>Filter by network name.</summary>
     [JsonPropertyName("network")]
     public string? Network { get; set; }
 
+    /// <summary>Optional probe tags.</summary>
     [JsonPropertyName("tags")]
     public List<string>? Tags { get; set; }
 }

--- a/Globalping/Models/MeasurementRequest.cs
+++ b/Globalping/Models/MeasurementRequest.cs
@@ -3,19 +3,27 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Request payload for creating a measurement.
+/// </summary>
 public class MeasurementRequest {
+    /// <summary>Type of measurement to execute.</summary>
     [JsonPropertyName("type")]
     public MeasurementType Type { get; set; }
 
+    /// <summary>Target host or address.</summary>
     [JsonPropertyName("target")]
     public string Target { get; set; } = string.Empty;
 
+    /// <summary>Whether to receive updates while running.</summary>
     [JsonPropertyName("inProgressUpdates")]
     public bool InProgressUpdates { get; set; } = false;
 
+    /// <summary>Explicit probe locations.</summary>
     [JsonIgnore]
     public List<LocationRequest>? Locations { get; set; }
 
+    /// <summary>Reuse probe selection from another measurement.</summary>
     [JsonIgnore]
     public string? ReuseLocationsFromId { get; set; }
 
@@ -23,9 +31,11 @@ public class MeasurementRequest {
     public object? SerializedLocations =>
         (object?)ReuseLocationsFromId ?? Locations;
 
+    /// <summary>Maximum number of probes to select.</summary>
     [JsonPropertyName("limit")]
     public int? Limit { get; set; }
 
+    /// <summary>Measurement specific options.</summary>
     [JsonPropertyName("measurementOptions")]
     public IMeasurementOptions? MeasurementOptions { get; set; }
 }

--- a/Globalping/Models/MtrOptions.cs
+++ b/Globalping/Models/MtrOptions.cs
@@ -1,17 +1,24 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Options for the MTR (My Traceroute) measurement.
+/// </summary>
 public class MtrOptions : IMeasurementOptions
 {
+    /// <summary>Destination port for the test.</summary>
     [JsonPropertyName("port")]
     public int Port { get; set; } = 80;
 
+    /// <summary>Transport protocol to use.</summary>
     [JsonPropertyName("protocol")]
     public MtrProtocol Protocol { get; set; } = MtrProtocol.ICMP;
 
+    /// <summary>IP version used for destination resolution.</summary>
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;
 
+    /// <summary>Number of packets to send.</summary>
     [JsonPropertyName("packets")]
     public int Packets { get; set; } = 3;
 }

--- a/Globalping/Models/PingOptions.cs
+++ b/Globalping/Models/PingOptions.cs
@@ -1,10 +1,15 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Options for an ICMP ping measurement.
+/// </summary>
 public class PingOptions : IMeasurementOptions {
+    /// <summary>Number of echo requests to send.</summary>
     [JsonPropertyName("packets")]
     public int Packets { get; set; } = 3;
 
+    /// <summary>IP protocol version used to resolve the target.</summary>
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;
 }

--- a/Globalping/Models/Probes.cs
+++ b/Globalping/Models/Probes.cs
@@ -3,16 +3,23 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>
+/// Represents a probe available for running measurements.
+/// </summary>
 public class Probes {
+    /// <summary>Probe software version.</summary>
     [JsonPropertyName("version")]
     public string Version { get; set; } = string.Empty;
 
+    /// <summary>Geographical information about the probe.</summary>
     [JsonPropertyName("location")]
     public Location? Location { get; set; }
 
+    /// <summary>Tags describing the probe.</summary>
     [JsonPropertyName("tags")]
     public List<string>? Tags { get; set; }
 
+    /// <summary>DNS resolvers configured for the probe.</summary>
     [JsonPropertyName("resolvers")]
     public List<string>? Resolvers { get; set; }
 }

--- a/Globalping/Models/TracerouteOptions.cs
+++ b/Globalping/Models/TracerouteOptions.cs
@@ -1,13 +1,19 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>
+/// Options used when executing a traceroute measurement.
+/// </summary>
 public class TracerouteOptions : IMeasurementOptions {
+    /// <summary>Destination port for traceroute packets.</summary>
     [JsonPropertyName("port")]
     public int Port { get; set; } = 80;
 
+    /// <summary>Protocol used to send traceroute packets.</summary>
     [JsonPropertyName("protocol")]
     public TracerouteProtocol Protocol { get; set; } = TracerouteProtocol.ICMP;
 
+    /// <summary>IP version used when resolving the target.</summary>
     [JsonPropertyName("ipVersion")]
     public IpVersion IpVersion { get; set; } = IpVersion.Four;
 }


### PR DESCRIPTION
## Summary
- add missing `<summary>` comments for enums and model classes
- document marker interface and measurement option fields
- regenerate documentation via `dotnet build`

## Testing
- `dotnet build /property:GenerateDocumentationFile=true`

------
https://chatgpt.com/codex/tasks/task_e_6857b539be48832ea3f6952dc8afad79