### PR TITLE
Add cancellation tokens and HTTP version enum

### DIFF
--- a/Globalping.Tests/ResultExtensionsTests.cs
+++ b/Globalping.Tests/ResultExtensionsTests.cs
@@ -47,7 +47,7 @@ public class ResultExtensionsTests
 
         var http = result.ToHttpResponse("example.com");
         Assert.NotNull(http);
-        Assert.Equal("HTTP/1.1", http!.Protocol);
+        Assert.Equal(HttpProtocolVersion.Http11, http!.Protocol);
         Assert.Equal(200, http.StatusCode);
         Assert.Equal("hello", http.Body);
         Assert.True(http.Headers.ContainsKey("Content-Type"));

--- a/Globalping/Enums/DnsQueryType.cs
+++ b/Globalping/Enums/DnsQueryType.cs
@@ -1,8 +1,11 @@
+using System.Text.Json.Serialization;
+
 namespace Globalping;
 
 /// <summary>
 /// Common DNS record types that can be queried.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum DnsQueryType
 {
     /// <summary>IPv4 host address record.</summary>

--- a/Globalping/Enums/HttpProtocolVersion.cs
+++ b/Globalping/Enums/HttpProtocolVersion.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+/// <summary>
+/// HTTP response protocol versions.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum HttpProtocolVersion
+{
+    /// <summary>Unknown HTTP version.</summary>
+    Unknown,
+
+    /// <summary>HTTP/1.0.</summary>
+    Http10,
+
+    /// <summary>HTTP/1.1.</summary>
+    Http11,
+
+    /// <summary>HTTP/2.</summary>
+    Http20,
+
+    /// <summary>HTTP/3.</summary>
+    Http30
+}

--- a/Globalping/Enums/MeasurementStatus.cs
+++ b/Globalping/Enums/MeasurementStatus.cs
@@ -5,6 +5,7 @@ namespace Globalping;
 /// <summary>
 /// Current processing state of a measurement.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MeasurementStatus
 {
     /// <summary>Measurement is still running.</summary>

--- a/Globalping/Enums/MeasurementType.cs
+++ b/Globalping/Enums/MeasurementType.cs
@@ -4,6 +4,7 @@ namespace Globalping;
 /// <summary>
 /// Supported measurement types that can be executed on a probe.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MeasurementType {
     /// <summary>ICMP ping measurement.</summary>
     Ping,

--- a/Globalping/Enums/TestStatus.cs
+++ b/Globalping/Enums/TestStatus.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TestStatus
 {
     InProgress,

--- a/Globalping/HttpResponseResult.cs
+++ b/Globalping/HttpResponseResult.cs
@@ -5,7 +5,7 @@ namespace Globalping;
 public class HttpResponseResult
 {
     public string Target { get; set; } = string.Empty;
-    public string Protocol { get; set; } = string.Empty;
+    public HttpProtocolVersion Protocol { get; set; } = HttpProtocolVersion.Unknown;
     public int StatusCode { get; set; }
     public string StatusDescription { get; set; } = string.Empty;
     public Dictionary<string, object?> Headers { get; set; } = new(StringComparer.OrdinalIgnoreCase);

--- a/Globalping/MeasurementResponseExtensions.cs
+++ b/Globalping/MeasurementResponseExtensions.cs
@@ -577,7 +577,7 @@ public static class MeasurementResponseExtensions {
         if (data.RawHeaders != null) {
             var resp = new HttpResponseResult
             {
-                Protocol = string.Empty,
+                Protocol = HttpProtocolVersion.Unknown,
                 StatusCode = data.StatusCode ?? 0,
                 StatusDescription = data.StatusCodeName ?? string.Empty,
                 Body = data.RawBody,
@@ -608,8 +608,9 @@ public static class MeasurementResponseExtensions {
         if (lines.Length > 0) {
             var first = lines[0].Trim();
             var m = Regex.Match(first, "^(HTTP/\\S+)\\s+(\\d{3})\\s*(.*)$");
-            if (m.Success) {
-                result.Protocol = m.Groups[1].Value;
+            if (m.Success)
+            {
+                result.Protocol = ParseHttpVersion(m.Groups[1].Value);
                 result.StatusCode = int.Parse(m.Groups[2].Value);
                 result.StatusDescription = m.Groups[3].Value.Trim();
             }
@@ -650,6 +651,18 @@ public static class MeasurementResponseExtensions {
         result.Tls = data.Tls;
 
         return new List<HttpResponseResult> { result };
+    }
+
+    private static HttpProtocolVersion ParseHttpVersion(string version)
+    {
+        return version switch
+        {
+            "HTTP/1.0" => HttpProtocolVersion.Http10,
+            "HTTP/1.1" => HttpProtocolVersion.Http11,
+            "HTTP/2" or "HTTP/2.0" => HttpProtocolVersion.Http20,
+            "HTTP/3" or "HTTP/3.0" => HttpProtocolVersion.Http30,
+            _ => HttpProtocolVersion.Unknown
+        };
     }
 
     private static object? Normalize(List<string> values)


### PR DESCRIPTION
## Summary
- support `CancellationToken` in `ProbeService` and `MeasurementClient`
- parse HTTP response protocol using new `HttpProtocolVersion` enum
- serialize core enums consistently
- show cancellation token usage and protocol output in HTTP example
- update unit tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68790cc6bf50832e806cd4bbe2a594bf