### PR TITLE
Address enum duplication for country codes

### DIFF
--- a/Globalping.Examples/Examples/BuildRequestExample.cs
+++ b/Globalping.Examples/Examples/BuildRequestExample.cs
@@ -11,15 +11,15 @@ public static class BuildRequestExample
         var builder = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("cdn.jsdelivr.net")
-            .AddCountry("DE")
-            .AddCountry("PL");
+            .AddCountry(CountryCode.Germany)
+            .AddCountry(CountryCode.Poland);
         ConsoleHelpers.WriteJson(builder.Build(), "Request 1");
 
         builder = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("cdn.jsdelivr.net")
-            .AddCountry("DE", 4)
-            .AddCountry("PL", 2);
+            .AddCountry(CountryCode.Germany, 4)
+            .AddCountry(CountryCode.Poland, 2);
         ConsoleHelpers.WriteJson(builder.Build(), "Request 2");
 
         builder = new MeasurementRequestBuilder()

--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -157,9 +157,9 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
             {
                 foreach (var loc in SimpleLocations)
                 {
-                    if (loc.Length == 2)
+                    if (CountryCodeExtensions.TryParse(loc, out var code))
                     {
-                        builder.AddCountry(loc);
+                        builder.AddCountry(code);
                     }
                     else
                     {

--- a/Globalping.Tests/AdditionalCoverageExtraTests.cs
+++ b/Globalping.Tests/AdditionalCoverageExtraTests.cs
@@ -73,10 +73,10 @@ public class AdditionalCoverageExtraTests
         var request = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("example.com")
-            .AddLocation(new LocationRequest { Country = "DE", Limit = 1 })
+            .AddLocation(new LocationRequest { Country = CountryCode.Germany, Limit = 1 })
             .Build();
         Assert.Single(request.Locations!);
-        Assert.Equal("DE", request.Locations![0].Country);
+        Assert.Equal(CountryCode.Germany, request.Locations![0].Country);
         Assert.Equal(1, request.Locations![0].Limit);
     }
 

--- a/Globalping.Tests/AdditionalCoverageMoreTests.cs
+++ b/Globalping.Tests/AdditionalCoverageMoreTests.cs
@@ -170,7 +170,7 @@ public class AdditionalCoverageMoreTests
             .WithType(MeasurementType.Ping)
             .WithTarget("example.com")
             .ReuseLocationsFromId("old")
-            .WithLocations(new[]{ new LocationRequest{ Country="DE" } });
+            .WithLocations(new[]{ new LocationRequest{ Country = CountryCode.Germany } });
         var request = builder.Build();
         Assert.Null(request.ReuseLocationsFromId);
         Assert.NotNull(request.Locations);

--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -14,6 +14,7 @@ public sealed class MeasurementRequestTests
 
     static MeasurementRequestTests()
     {
+        JsonOptions.Converters.Add(new CountryCodeConverter());
         JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
 
@@ -43,8 +44,8 @@ public sealed class MeasurementRequestTests
         var request = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("example.com")
-            .AddCountry("DE")
-            .AddCountry("US")
+            .AddCountry(CountryCode.Germany)
+            .AddCountry(CountryCode.UnitedStates)
             .Build();
 
         var json = JsonSerializer.Serialize(request, JsonOptions);
@@ -64,7 +65,7 @@ public sealed class MeasurementRequestTests
             .WithType(MeasurementType.Ping)
             .WithTarget("example.com")
             .ReuseLocationsFromId("old")
-            .AddCountry("DE")
+            .AddCountry(CountryCode.Germany)
             .Build();
 
         Assert.Null(request.ReuseLocationsFromId);
@@ -77,7 +78,7 @@ public sealed class MeasurementRequestTests
         var request = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("example.com")
-            .AddCountry("DE")
+            .AddCountry(CountryCode.Germany)
             .ReuseLocationsFromId("new")
             .Build();
 

--- a/Globalping.Tests/MeasurementResponseDeserializationTests.cs
+++ b/Globalping.Tests/MeasurementResponseDeserializationTests.cs
@@ -16,6 +16,7 @@ public sealed class MeasurementResponseDeserializationTests
     {
         JsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
         JsonOptions.Converters.Add(new JsonStringEnumConverter<TestStatus>(JsonNamingPolicy.KebabCaseLower));
+        JsonOptions.Converters.Add(new CountryCodeConverter());
         JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     }
     [Fact]
@@ -40,7 +41,7 @@ public sealed class MeasurementResponseDeserializationTests
         Assert.NotNull(response);
         Assert.NotNull(response!.Locations);
         Assert.Single(response.Locations!);
-        Assert.Equal("DE", response.Locations![0].Country);
+        Assert.Equal(CountryCode.Germany, response.Locations![0].Country);
         Assert.Equal(1, response.Locations![0].Limit);
         Assert.Equal(1, response.Limit);
     }

--- a/Globalping/Enums/CountryCode.cs
+++ b/Globalping/Enums/CountryCode.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Globalping;
+
+/// <summary>
+/// ISO 3166-1 alpha-2 country codes.
+/// </summary>
+[JsonConverter(typeof(CountryCodeConverter))]
+public enum CountryCode
+{
+    [EnumMember(Value = "AF")] Afghanistan,
+    [EnumMember(Value = "AX")] AlandIslands,
+    [EnumMember(Value = "AL")] Albania,
+    [EnumMember(Value = "DZ")] Algeria,
+    [EnumMember(Value = "AS")] AmericanSamoa,
+    [EnumMember(Value = "AD")] Andorra,
+    [EnumMember(Value = "AO")] Angola,
+    [EnumMember(Value = "AI")] Anguilla,
+    [EnumMember(Value = "AQ")] Antarctica,
+    [EnumMember(Value = "AG")] AntiguaAndBarbuda,
+    [EnumMember(Value = "AR")] Argentina,
+    [EnumMember(Value = "AM")] Armenia,
+    [EnumMember(Value = "AW")] Aruba,
+    [EnumMember(Value = "AU")] Australia,
+    [EnumMember(Value = "AT")] Austria,
+    [EnumMember(Value = "AZ")] Azerbaijan,
+    [EnumMember(Value = "BS")] Bahamas,
+    [EnumMember(Value = "BH")] Bahrain,
+    [EnumMember(Value = "BD")] Bangladesh,
+    [EnumMember(Value = "BB")] Barbados,
+    [EnumMember(Value = "BY")] Belarus,
+    [EnumMember(Value = "BE")] Belgium,
+    [EnumMember(Value = "BZ")] Belize,
+    [EnumMember(Value = "BJ")] Benin,
+    [EnumMember(Value = "BM")] Bermuda,
+    [EnumMember(Value = "BT")] Bhutan,
+    [EnumMember(Value = "BO")] BoliviaPlurinationalStateOf,
+    [EnumMember(Value = "BQ")] BonaireSintEustatiusAndSaba,
+    [EnumMember(Value = "BA")] BosniaAndHerzegovina,
+    [EnumMember(Value = "BW")] Botswana,
+    [EnumMember(Value = "BV")] BouvetIsland,
+    [EnumMember(Value = "BR")] Brazil,
+    [EnumMember(Value = "IO")] BritishIndianOceanTerritory,
+    [EnumMember(Value = "BN")] BruneiDarussalam,
+    [EnumMember(Value = "BG")] Bulgaria,
+    [EnumMember(Value = "BF")] BurkinaFaso,
+    [EnumMember(Value = "BI")] Burundi,
+    [EnumMember(Value = "KH")] Cambodia,
+    [EnumMember(Value = "CM")] Cameroon,
+    [EnumMember(Value = "CA")] Canada,
+    [EnumMember(Value = "CV")] CapeVerde,
+    [EnumMember(Value = "KY")] CaymanIslands,
+    [EnumMember(Value = "CF")] CentralAfricanRepublic,
+    [EnumMember(Value = "TD")] Chad,
+    [EnumMember(Value = "CL")] Chile,
+    [EnumMember(Value = "CN")] China,
+    [EnumMember(Value = "CX")] ChristmasIsland,
+    [EnumMember(Value = "CC")] CocosKeelingIslands,
+    [EnumMember(Value = "CO")] Colombia,
+    [EnumMember(Value = "KM")] Comoros,
+    [EnumMember(Value = "CG")] Congo,
+    [EnumMember(Value = "CD")] CongoTheDemocraticRepublicOfThe,
+    [EnumMember(Value = "CK")] CookIslands,
+    [EnumMember(Value = "CR")] CostaRica,
+    [EnumMember(Value = "CI")] CoteDIvoire,
+    [EnumMember(Value = "HR")] Croatia,
+    [EnumMember(Value = "CU")] Cuba,
+    [EnumMember(Value = "CW")] Curacao,
+    [EnumMember(Value = "CY")] Cyprus,
+    [EnumMember(Value = "CZ")] CzechRepublic,
+    [EnumMember(Value = "DK")] Denmark,
+    [EnumMember(Value = "DJ")] Djibouti,
+    [EnumMember(Value = "DM")] Dominica,
+    [EnumMember(Value = "DO")] DominicanRepublic,
+    [EnumMember(Value = "EC")] Ecuador,
+    [EnumMember(Value = "EG")] Egypt,
+    [EnumMember(Value = "SV")] ElSalvador,
+    [EnumMember(Value = "GQ")] EquatorialGuinea,
+    [EnumMember(Value = "ER")] Eritrea,
+    [EnumMember(Value = "EE")] Estonia,
+    [EnumMember(Value = "ET")] Ethiopia,
+    [EnumMember(Value = "FK")] FalklandIslandsMalvinas,
+    [EnumMember(Value = "FO")] FaroeIslands,
+    [EnumMember(Value = "FJ")] Fiji,
+    [EnumMember(Value = "FI")] Finland,
+    [EnumMember(Value = "FR")] France,
+    [EnumMember(Value = "GF")] FrenchGuiana,
+    [EnumMember(Value = "PF")] FrenchPolynesia,
+    [EnumMember(Value = "TF")] FrenchSouthernTerritories,
+    [EnumMember(Value = "GA")] Gabon,
+    [EnumMember(Value = "GM")] Gambia,
+    [EnumMember(Value = "GE")] Georgia,
+    [EnumMember(Value = "DE")] Germany,
+    [EnumMember(Value = "GH")] Ghana,
+    [EnumMember(Value = "GI")] Gibraltar,
+    [EnumMember(Value = "GR")] Greece,
+    [EnumMember(Value = "GL")] Greenland,
+    [EnumMember(Value = "GD")] Grenada,
+    [EnumMember(Value = "GP")] Guadeloupe,
+    [EnumMember(Value = "GU")] Guam,
+    [EnumMember(Value = "GT")] Guatemala,
+    [EnumMember(Value = "GG")] Guernsey,
+    [EnumMember(Value = "GN")] Guinea,
+    [EnumMember(Value = "GW")] GuineaBissau,
+    [EnumMember(Value = "GY")] Guyana,
+    [EnumMember(Value = "HT")] Haiti,
+    [EnumMember(Value = "HM")] HeardIslandAndMcdonaldIslands,
+    [EnumMember(Value = "VA")] HolySeeVaticanCityState,
+    [EnumMember(Value = "HN")] Honduras,
+    [EnumMember(Value = "HK")] HongKong,
+    [EnumMember(Value = "HU")] Hungary,
+    [EnumMember(Value = "IS")] Iceland,
+    [EnumMember(Value = "IN")] India,
+    [EnumMember(Value = "ID")] Indonesia,
+    [EnumMember(Value = "IR")] IranIslamicRepublicOf,
+    [EnumMember(Value = "IQ")] Iraq,
+    [EnumMember(Value = "IE")] Ireland,
+    [EnumMember(Value = "IM")] IsleOfMan,
+    [EnumMember(Value = "IL")] Israel,
+    [EnumMember(Value = "IT")] Italy,
+    [EnumMember(Value = "JM")] Jamaica,
+    [EnumMember(Value = "JP")] Japan,
+    [EnumMember(Value = "JE")] Jersey,
+    [EnumMember(Value = "JO")] Jordan,
+    [EnumMember(Value = "KZ")] Kazakhstan,
+    [EnumMember(Value = "KE")] Kenya,
+    [EnumMember(Value = "KI")] Kiribati,
+    [EnumMember(Value = "KP")] KoreaDemocraticPeopleSRepublicOf,
+    [EnumMember(Value = "KR")] KoreaRepublicOf,
+    [EnumMember(Value = "KW")] Kuwait,
+    [EnumMember(Value = "KG")] Kyrgyzstan,
+    [EnumMember(Value = "LA")] LaoPeopleSDemocraticRepublic,
+    [EnumMember(Value = "LV")] Latvia,
+    [EnumMember(Value = "LB")] Lebanon,
+    [EnumMember(Value = "LS")] Lesotho,
+    [EnumMember(Value = "LR")] Liberia,
+    [EnumMember(Value = "LY")] Libya,
+    [EnumMember(Value = "LI")] Liechtenstein,
+    [EnumMember(Value = "LT")] Lithuania,
+    [EnumMember(Value = "LU")] Luxembourg,
+    [EnumMember(Value = "MO")] Macao,
+    [EnumMember(Value = "MK")] MacedoniaTheFormerYugoslavRepublicOf,
+    [EnumMember(Value = "MG")] Madagascar,
+    [EnumMember(Value = "MW")] Malawi,
+    [EnumMember(Value = "MY")] Malaysia,
+    [EnumMember(Value = "MV")] Maldives,
+    [EnumMember(Value = "ML")] Mali,
+    [EnumMember(Value = "MT")] Malta,
+    [EnumMember(Value = "MH")] MarshallIslands,
+    [EnumMember(Value = "MQ")] Martinique,
+    [EnumMember(Value = "MR")] Mauritania,
+    [EnumMember(Value = "MU")] Mauritius,
+    [EnumMember(Value = "YT")] Mayotte,
+    [EnumMember(Value = "MX")] Mexico,
+    [EnumMember(Value = "FM")] MicronesiaFederatedStatesOf,
+    [EnumMember(Value = "MD")] MoldovaRepublicOf,
+    [EnumMember(Value = "MC")] Monaco,
+    [EnumMember(Value = "MN")] Mongolia,
+    [EnumMember(Value = "ME")] Montenegro,
+    [EnumMember(Value = "MS")] Montserrat,
+    [EnumMember(Value = "MA")] Morocco,
+    [EnumMember(Value = "MZ")] Mozambique,
+    [EnumMember(Value = "MM")] Myanmar,
+    [EnumMember(Value = "NA")] Namibia,
+    [EnumMember(Value = "NR")] Nauru,
+    [EnumMember(Value = "NP")] Nepal,
+    [EnumMember(Value = "NL")] Netherlands,
+    [EnumMember(Value = "NC")] NewCaledonia,
+    [EnumMember(Value = "NZ")] NewZealand,
+    [EnumMember(Value = "NI")] Nicaragua,
+    [EnumMember(Value = "NE")] Niger,
+    [EnumMember(Value = "NG")] Nigeria,
+    [EnumMember(Value = "NU")] Niue,
+    [EnumMember(Value = "NF")] NorfolkIsland,
+    [EnumMember(Value = "MP")] NorthernMarianaIslands,
+    [EnumMember(Value = "NO")] Norway,
+    [EnumMember(Value = "OM")] Oman,
+    [EnumMember(Value = "PK")] Pakistan,
+    [EnumMember(Value = "PW")] Palau,
+    [EnumMember(Value = "PS")] PalestineStateOf,
+    [EnumMember(Value = "PA")] Panama,
+    [EnumMember(Value = "PG")] PapuaNewGuinea,
+    [EnumMember(Value = "PY")] Paraguay,
+    [EnumMember(Value = "PE")] Peru,
+    [EnumMember(Value = "PH")] Philippines,
+    [EnumMember(Value = "PN")] Pitcairn,
+    [EnumMember(Value = "PL")] Poland,
+    [EnumMember(Value = "PT")] Portugal,
+    [EnumMember(Value = "PR")] PuertoRico,
+    [EnumMember(Value = "QA")] Qatar,
+    [EnumMember(Value = "RE")] Reunion,
+    [EnumMember(Value = "RO")] Romania,
+    [EnumMember(Value = "RU")] RussianFederation,
+    [EnumMember(Value = "RW")] Rwanda,
+    [EnumMember(Value = "BL")] SaintBarthelemy,
+    [EnumMember(Value = "SH")] SaintHelenaAscensionAndTristanDaCunha,
+    [EnumMember(Value = "KN")] SaintKittsAndNevis,
+    [EnumMember(Value = "LC")] SaintLucia,
+    [EnumMember(Value = "MF")] SaintMartinFrenchPart,
+    [EnumMember(Value = "PM")] SaintPierreAndMiquelon,
+    [EnumMember(Value = "VC")] SaintVincentAndTheGrenadines,
+    [EnumMember(Value = "WS")] Samoa,
+    [EnumMember(Value = "SM")] SanMarino,
+    [EnumMember(Value = "ST")] SaoTomeAndPrincipe,
+    [EnumMember(Value = "SA")] SaudiArabia,
+    [EnumMember(Value = "SN")] Senegal,
+    [EnumMember(Value = "RS")] Serbia,
+    [EnumMember(Value = "SC")] Seychelles,
+    [EnumMember(Value = "SL")] SierraLeone,
+    [EnumMember(Value = "SG")] Singapore,
+    [EnumMember(Value = "SX")] SintMaartenDutchPart,
+    [EnumMember(Value = "SK")] Slovakia,
+    [EnumMember(Value = "SI")] Slovenia,
+    [EnumMember(Value = "SB")] SolomonIslands,
+    [EnumMember(Value = "SO")] Somalia,
+    [EnumMember(Value = "ZA")] SouthAfrica,
+    [EnumMember(Value = "GS")] SouthGeorgiaAndTheSouthSandwichIslands,
+    [EnumMember(Value = "SS")] SouthSudan,
+    [EnumMember(Value = "ES")] Spain,
+    [EnumMember(Value = "LK")] SriLanka,
+    [EnumMember(Value = "SD")] Sudan,
+    [EnumMember(Value = "SR")] Suriname,
+    [EnumMember(Value = "SJ")] SvalbardAndJanMayen,
+    [EnumMember(Value = "SZ")] Eswatini,
+    [EnumMember(Value = "SE")] Sweden,
+    [EnumMember(Value = "CH")] Switzerland,
+    [EnumMember(Value = "SY")] SyrianArabRepublic,
+    [EnumMember(Value = "TW")] TaiwanProvinceOfChina,
+    [EnumMember(Value = "TJ")] Tajikistan,
+    [EnumMember(Value = "TZ")] TanzaniaUnitedRepublicOf,
+    [EnumMember(Value = "TH")] Thailand,
+    [EnumMember(Value = "TL")] TimorLeste,
+    [EnumMember(Value = "TG")] Togo,
+    [EnumMember(Value = "TK")] Tokelau,
+    [EnumMember(Value = "TO")] Tonga,
+    [EnumMember(Value = "TT")] TrinidadAndTobago,
+    [EnumMember(Value = "TN")] Tunisia,
+    [EnumMember(Value = "TR")] Turkey,
+    [EnumMember(Value = "TM")] Turkmenistan,
+    [EnumMember(Value = "TC")] TurksAndCaicosIslands,
+    [EnumMember(Value = "TV")] Tuvalu,
+    [EnumMember(Value = "UG")] Uganda,
+    [EnumMember(Value = "UA")] Ukraine,
+    [EnumMember(Value = "AE")] UnitedArabEmirates,
+    [EnumMember(Value = "GB")] UnitedKingdom,
+    [EnumMember(Value = "US")] UnitedStates,
+    [EnumMember(Value = "UM")] UnitedStatesMinorOutlyingIslands,
+    [EnumMember(Value = "UY")] Uruguay,
+    [EnumMember(Value = "UZ")] Uzbekistan,
+    [EnumMember(Value = "VU")] Vanuatu,
+    [EnumMember(Value = "VE")] VenezuelaBolivarianRepublicOf,
+    [EnumMember(Value = "VN")] VietNam,
+    [EnumMember(Value = "VG")] VirginIslandsBritish,
+    [EnumMember(Value = "VI")] VirginIslandsUS,
+    [EnumMember(Value = "WF")] WallisAndFutuna,
+    [EnumMember(Value = "EH")] WesternSahara,
+    [EnumMember(Value = "YE")] Yemen,
+    [EnumMember(Value = "ZM")] Zambia,
+    [EnumMember(Value = "ZW")] Zimbabwe,
+}
+
+public sealed class CountryCodeConverter : JsonConverter<CountryCode>
+{
+    internal static readonly Dictionary<string, CountryCode> Map;
+
+    static CountryCodeConverter()
+    {
+        Map = new Dictionary<string, CountryCode>(StringComparer.OrdinalIgnoreCase);
+        foreach (CountryCode code in Enum.GetValues(typeof(CountryCode)))
+        {
+            var value = GetValue(code);
+            Map[value] = code;
+        }
+    }
+
+    internal static string GetValue(CountryCode code)
+    {
+        var member = typeof(CountryCode).GetMember(code.ToString())[0];
+        var attr = (EnumMemberAttribute?)Attribute.GetCustomAttribute(member, typeof(EnumMemberAttribute));
+        return attr?.Value ?? code.ToString();
+    }
+
+    public override CountryCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var raw = reader.GetString();
+        if (raw is null)
+        {
+            throw new JsonException("Country code was null");
+        }
+
+        string value = raw!;
+        if (Map.TryGetValue(value, out var code))
+        {
+            return code;
+        }
+
+        throw new JsonException($"Invalid country code '{value}'");
+    }
+
+    public override void Write(Utf8JsonWriter writer, CountryCode value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(GetValue(value));
+    }
+}
+
+public static class CountryCodeExtensions
+{
+    public static bool TryParse(string? value, out CountryCode code)
+    {
+        if (!string.IsNullOrEmpty(value))
+        {
+            if (CountryCodeConverter.Map.TryGetValue(value!, out code))
+            {
+                return true;
+            }
+            if (Enum.TryParse(value!, true, out code))
+            {
+                return true;
+            }
+        }
+        code = default;
+        return false;
+    }
+
+    public static string ToValueString(this CountryCode code) => CountryCodeConverter.GetValue(code);
+}

--- a/Globalping/MeasurementRequestBuilder.cs
+++ b/Globalping/MeasurementRequestBuilder.cs
@@ -28,7 +28,7 @@ public class MeasurementRequestBuilder
         return this;
     }
 
-    public MeasurementRequestBuilder AddCountry(string country, int? limit = null)
+    public MeasurementRequestBuilder AddCountry(CountryCode country, int? limit = null)
     {
         var loc = new LocationRequest { Country = country, Limit = limit };
         return AddLocation(loc);

--- a/Globalping/Models/LocationRequest.cs
+++ b/Globalping/Models/LocationRequest.cs
@@ -15,9 +15,9 @@ public class LocationRequest {
     [JsonPropertyName("region")]
     public RegionName? Region { get; set; }
 
-    /// <summary>ISO country name.</summary>
+    /// <summary>ISO country code.</summary>
     [JsonPropertyName("country")]
-    public string? Country { get; set; }
+    public CountryCode? Country { get; set; }
 
     /// <summary>State or province within the country.</summary>
     [JsonPropertyName("state")]

--- a/Module/Examples/Example-PingMultiLocationAdvanced.ps1
+++ b/Module/Examples/Example-PingMultiLocationAdvanced.ps1
@@ -1,16 +1,16 @@
 ﻿Import-Module $PSScriptRoot\..\Globalping.psd1 -Force
 
 $loc = @(
-    [Globalping.LocationRequest]@{ Country = "DE"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "US"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "GB"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "PL"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "FR"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "IT"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "ES"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "NL"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "SE"; Limit = 1 },
-    [Globalping.LocationRequest]@{ Country = "CH"; Limit = 1 }
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Germany; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::UnitedStates; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::UnitedKingdom; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Poland; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::France; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Italy; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Spain; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Netherlands; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Sweden; Limit = 1 },
+    [Globalping.LocationRequest]@{ Country = [Globalping.CountryCode]::Switzerland; Limit = 1 }
 )
 $locResult = Start-GlobalpingPing -Target "evotec.xyz" -Verbose -Locations $loc -ApiKey $env:GLOBALPING_TOKEN
 $locResult | Format-Table


### PR DESCRIPTION
## Summary
- replace huge lookup table with reflection-based mapping in `CountryCodeConverter`
- adjust parsing helpers to work with new converter

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68791441ad44832e82820f1e4a1f424e