### PR TITLE
Add tests for PowerShell module resolver

### DIFF
--- a/Globalping.PowerShell.Tests/Globalping.PowerShell.Tests.csproj
+++ b/Globalping.PowerShell.Tests/Globalping.PowerShell.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Globalping.PowerShell\Globalping.PowerShell.csproj" />
+  </ItemGroup>
+</Project>

--- a/Globalping.PowerShell.Tests/OnModuleImportAndRemoveTests.cs
+++ b/Globalping.PowerShell.Tests/OnModuleImportAndRemoveTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Globalping.PowerShell;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Globalping.PowerShell.Tests;
+
+public class OnModuleImportAndRemoveTests
+{
+    [Fact]
+    public void ResolverLoadsAssemblyFromCustomDirectory()
+    {
+        var initializer = new OnModuleImportAndRemove();
+        initializer.OnImport();
+
+        var libDir = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location)!;
+        var tempDir = Path.Combine(libDir, Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var asmName = "TempAssembly" + Guid.NewGuid().ToString("N");
+        var asmPath = Path.Combine(tempDir, asmName + ".dll");
+        BuildDummyAssembly(asmName, asmPath);
+
+        try
+        {
+            if (IsNetFramework())
+            {
+                var asm = Assembly.Load(asmName);
+                Assert.Equal(asmName, asm.GetName().Name);
+            }
+            else
+            {
+                Assert.Throws<FileNotFoundException>(() => Assembly.Load(asmName));
+            }
+        }
+        finally
+        {
+            initializer.OnRemove(null!);
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ResolverIsRemovedAfterOnRemove()
+    {
+        var initializer = new OnModuleImportAndRemove();
+        initializer.OnImport();
+
+        var libDir = Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location)!;
+        var tempDir = Path.Combine(libDir, Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var asmName = "TempAssembly" + Guid.NewGuid().ToString("N");
+        var asmPath = Path.Combine(tempDir, asmName + ".dll");
+        BuildDummyAssembly(asmName, asmPath);
+        initializer.OnRemove(null!);
+
+        try
+        {
+            Assert.Throws<FileNotFoundException>(() => Assembly.Load(asmName));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private static void BuildDummyAssembly(string name, string path)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText("public class Dummy {}");
+        var references = new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) };
+        var compilation = CSharpCompilation.Create(name, new[] { syntaxTree }, references, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var result = compilation.Emit(path);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(string.Join(Environment.NewLine, result.Diagnostics));
+        }
+    }
+
+    private static bool IsNetFramework() => System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+}

--- a/Globalping.sln
+++ b/Globalping.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Globalping.PowerShell", "Gl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Globalping.Tests", "Globalping.Tests\Globalping.Tests.csproj", "{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Globalping.PowerShell.Tests", "Globalping.PowerShell.Tests\Globalping.PowerShell.Tests.csproj", "{735E9DEA-2D92-4B0C-B421-07D27243CEA0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,11 +34,15 @@ Global
 		{11683D44-F4FE-4004-9E18-92B868AAAB82}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11683D44-F4FE-4004-9E18-92B868AAAB82}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{11683D44-F4FE-4004-9E18-92B868AAAB82}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E0DAEE76-A866-4A28-9B37-2A46B6EEB380}.Release|Any CPU.Build.0 = Release|Any CPU
+                {735E9DEA-2D92-4B0C-B421-07D27243CEA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {735E9DEA-2D92-4B0C-B421-07D27243CEA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {735E9DEA-2D92-4B0C-B421-07D27243CEA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {735E9DEA-2D92-4B0C-B421-07D27243CEA0}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- create `Globalping.PowerShell.Tests` targeting net472 and net8.0
- cover `OnModuleImportAndRemove` assembly resolver
- add project to solution
- run module Pester tests

## Testing
- `dotnet test`
- `pwsh -f Module/Globalping.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6887d1d673f4832ead566c5bb710d30a