### PR TITLE
Refactor usage info parsing

### DIFF
--- a/Globalping/MeasurementClient.cs
+++ b/Globalping/MeasurementClient.cs
@@ -55,37 +55,7 @@ public class MeasurementClient {
 
     private void UpdateUsageInfo(HttpResponseMessage response)
     {
-        var headers = response.Headers;
-        LastResponseInfo = new ApiUsageInfo
-        {
-            RateLimitLimit = TryGetInt(headers, "X-RateLimit-Limit"),
-            RateLimitConsumed = TryGetInt(headers, "X-RateLimit-Consumed"),
-            RateLimitRemaining = TryGetInt(headers, "X-RateLimit-Remaining"),
-            RateLimitReset = TryGetLong(headers, "X-RateLimit-Reset"),
-            CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
-            CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
-            RequestCost = TryGetInt(headers, "X-Request-Cost"),
-            RetryAfter = TryGetInt(headers, "Retry-After"),
-            ETag = headers.ETag?.Tag
-        };
-    }
-
-    private static int? TryGetInt(HttpResponseHeaders headers, string name)
-    {
-        if (headers.TryGetValues(name, out var values) && int.TryParse(values.FirstOrDefault(), out var v))
-        {
-            return v;
-        }
-        return null;
-    }
-
-    private static long? TryGetLong(HttpResponseHeaders headers, string name)
-    {
-        if (headers.TryGetValues(name, out var values) && long.TryParse(values.FirstOrDefault(), out var v))
-        {
-            return v;
-        }
-        return null;
+        LastResponseInfo = UsageInfoParser.Parse(response);
     }
 
     private async Task EnsureSuccessOrThrow(HttpResponseMessage response)

--- a/Globalping/ProbeService.cs
+++ b/Globalping/ProbeService.cs
@@ -59,37 +59,7 @@ public class ProbeService {
 
     private void UpdateUsageInfo(HttpResponseMessage response)
     {
-        var headers = response.Headers;
-        LastResponseInfo = new ApiUsageInfo
-        {
-            RateLimitLimit = TryGetInt(headers, "X-RateLimit-Limit"),
-            RateLimitConsumed = TryGetInt(headers, "X-RateLimit-Consumed"),
-            RateLimitRemaining = TryGetInt(headers, "X-RateLimit-Remaining"),
-            RateLimitReset = TryGetLong(headers, "X-RateLimit-Reset"),
-            CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
-            CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
-            RequestCost = TryGetInt(headers, "X-Request-Cost"),
-            RetryAfter = TryGetInt(headers, "Retry-After"),
-            ETag = headers.ETag?.Tag
-        };
-    }
-
-    private static int? TryGetInt(HttpResponseHeaders headers, string name)
-    {
-        if (headers.TryGetValues(name, out var values) && int.TryParse(values.FirstOrDefault(), out var v))
-        {
-            return v;
-        }
-        return null;
-    }
-
-    private static long? TryGetLong(HttpResponseHeaders headers, string name)
-    {
-        if (headers.TryGetValues(name, out var values) && long.TryParse(values.FirstOrDefault(), out var v))
-        {
-            return v;
-        }
-        return null;
+        LastResponseInfo = UsageInfoParser.Parse(response);
     }
 
     private async Task EnsureSuccessOrThrow(HttpResponseMessage response)

--- a/Globalping/UsageInfoParser.cs
+++ b/Globalping/UsageInfoParser.cs
@@ -1,0 +1,46 @@
+namespace Globalping;
+
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+/// <summary>
+/// Helper class for parsing usage information from HTTP headers.
+/// </summary>
+internal static class UsageInfoParser
+{
+    internal static ApiUsageInfo Parse(HttpResponseMessage response)
+    {
+        var headers = response.Headers;
+        return new ApiUsageInfo
+        {
+            RateLimitLimit = TryGetInt(headers, "X-RateLimit-Limit"),
+            RateLimitConsumed = TryGetInt(headers, "X-RateLimit-Consumed"),
+            RateLimitRemaining = TryGetInt(headers, "X-RateLimit-Remaining"),
+            RateLimitReset = TryGetLong(headers, "X-RateLimit-Reset"),
+            CreditsConsumed = TryGetInt(headers, "X-Credits-Consumed"),
+            CreditsRemaining = TryGetInt(headers, "X-Credits-Remaining"),
+            RequestCost = TryGetInt(headers, "X-Request-Cost"),
+            RetryAfter = TryGetInt(headers, "Retry-After"),
+            ETag = headers.ETag?.Tag
+        };
+    }
+
+    private static int? TryGetInt(HttpResponseHeaders headers, string name)
+    {
+        if (headers.TryGetValues(name, out var values) && int.TryParse(values.FirstOrDefault(), out var v))
+        {
+            return v;
+        }
+        return null;
+    }
+
+    private static long? TryGetLong(HttpResponseHeaders headers, string name)
+    {
+        if (headers.TryGetValues(name, out var values) && long.TryParse(values.FirstOrDefault(), out var v))
+        {
+            return v;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- centralize usage info parsing logic in `UsageInfoParser`
- remove duplicated helper methods from `MeasurementClient` and `ProbeService`
- update both classes to use `UsageInfoParser`

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj --verbosity minimal`
- `dotnet test Globalping.PowerShell.Tests/Globalping.PowerShell.Tests.csproj --framework net8.0 --no-build --verbosity minimal`
- `dotnet build Globalping.sln --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6887d94dd448832eaff0fe9070835fb7