### PR TITLE
Add progress header and limit tests

### DIFF
--- a/Globalping.PowerShell/Properties/AssemblyInfo.cs
+++ b/Globalping.PowerShell/Properties/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Globalping.Tests")]

--- a/Globalping.Tests/AutomaticLimitCalculationTests.cs
+++ b/Globalping.Tests/AutomaticLimitCalculationTests.cs
@@ -1,0 +1,29 @@
+using Globalping.PowerShell;
+using Globalping;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class AutomaticLimitCalculationTests
+{
+    [Fact]
+    public void CalculatesLimitFromLocations()
+    {
+        var locations = new[]
+        {
+            new LocationRequest { Country = CountryCode.Germany },
+            new LocationRequest { City = "Berlin" }
+        };
+
+        var result = StartGlobalpingBaseCommand.ComputeLimit(null, false, null, null, locations);
+        Assert.Equal(2, result);
+    }
+
+    [Fact]
+    public void DefaultsToOneWhenNoLocations()
+    {
+        var result = StartGlobalpingBaseCommand.ComputeLimit(null, false, null, null, null);
+        Assert.Equal(1, result);
+    }
+}
+

--- a/Globalping.Tests/Globalping.Tests.csproj
+++ b/Globalping.Tests/Globalping.Tests.csproj
@@ -9,18 +9,19 @@
 		<IsTestProject>true</IsTestProject>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="coverlet.collector" Version="6.0.4">
+                        <PrivateAssets>all</PrivateAssets>
+                        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+                <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+                <PackageReference Include="xunit" Version="2.9.3" />
+                <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
+                        <PrivateAssets>all</PrivateAssets>
+                        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+                </PackageReference>
+                <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+        </ItemGroup>
 
         <ItemGroup>
                 <Using Include="Xunit" />
@@ -29,6 +30,7 @@
         <ItemGroup>
                 <ProjectReference Include="../Globalping/Globalping.csproj" />
                 <ProjectReference Include="../Globalping.Examples/Globalping.Examples.csproj" />
+                <ProjectReference Include="../Globalping.PowerShell/Globalping.PowerShell.csproj" />
         </ItemGroup>
 
 </Project>

--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -119,7 +119,9 @@ public class CaptureHandler : HttpMessageHandler
     }
 }
 "@
-        Add-Type -TypeDefinition $cs -Language CSharp | Out-Null
+        $httpDll = [System.Net.Http.HttpClient].Assembly.Location
+        $primitivesDll = [System.Net.HttpStatusCode].Assembly.Location
+        Add-Type -TypeDefinition $cs -Language CSharp -ReferencedAssemblies @($httpDll, $primitivesDll) | Out-Null
 
         $handler = [CaptureHandler]::new()
         $client = [System.Net.Http.HttpClient]::new($handler)

--- a/Module/Tests/Cmdlets.Tests.ps1
+++ b/Module/Tests/Cmdlets.Tests.ps1
@@ -96,4 +96,59 @@ Describe "Globalping Cmdlets" {
         { Start-GlobalpingPing -Target "evotec.xyz" -Limit 501 -ErrorAction Stop } |
             Should -Throw -ErrorId 'ParameterArgumentValidationError,Globalping.PowerShell.StartGlobalpingPingCommand'
     }
+
+    It "Sets Prefer header when waiting for updates" {
+        $cs = @"
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class CaptureHandler : HttpMessageHandler
+{
+    public HttpRequestMessage LastRequest { get; private set; }
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        LastRequest = request;
+        var resp = new HttpResponseMessage(HttpStatusCode.Accepted)
+        {
+            Content = new StringContent("{\"id\":\"1\",\"probesCount\":1}", Encoding.UTF8, "application/json")
+        };
+        return Task.FromResult(resp);
+    }
+}
+"@
+        Add-Type -TypeDefinition $cs -Language CSharp | Out-Null
+
+        $handler = [CaptureHandler]::new()
+        $client = [System.Net.Http.HttpClient]::new($handler)
+        $service = [Globalping.ProbeService]::new($client)
+
+        $builder = [Globalping.MeasurementRequestBuilder]::new()
+        $builder.WithType([Globalping.MeasurementType]::Ping) | Out-Null
+        $builder.WithTarget('example.com') | Out-Null
+        $req = $builder.Build()
+        $req.InProgressUpdates = $true
+
+        $null = $service.CreateMeasurementAsync($req, 42).GetAwaiter().GetResult()
+
+        $handler.LastRequest.Headers.GetValues('Prefer') | Should -Contain 'respond-async, wait=42'
+    }
+
+    It "Uses default wait time when not specified" {
+        $handler = [CaptureHandler]::new()
+        $client = [System.Net.Http.HttpClient]::new($handler)
+        $service = [Globalping.ProbeService]::new($client)
+
+        $builder = [Globalping.MeasurementRequestBuilder]::new()
+        $builder.WithType([Globalping.MeasurementType]::Ping) | Out-Null
+        $builder.WithTarget('example.com') | Out-Null
+        $req = $builder.Build()
+        $req.InProgressUpdates = $true
+
+        $null = $service.CreateMeasurementAsync($req).GetAwaiter().GetResult()
+
+        $handler.LastRequest.Headers.GetValues('Prefer') | Should -Contain 'respond-async, wait=150'
+    }
 }


### PR DESCRIPTION
## Summary
- expose a helper to compute automatic probe limits
- use new helper in cmdlet processing
- verify Prefer header behavior in PowerShell tests
- cover automatic limit calculation with unit tests

## Testing
- `dotnet build Globalping.sln -c Debug`
- `dotnet test Globalping.sln --no-build`
- `Invoke-Pester ./Module/Tests/Cmdlets.Tests.ps1 -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_6887d6bebe24832eac0d6f0e244010cd