### PR TITLE
Add generic WithOptions builder

### DIFF
--- a/Globalping.Examples/Examples/BuildRequestExample.cs
+++ b/Globalping.Examples/Examples/BuildRequestExample.cs
@@ -39,21 +39,21 @@ public static class BuildRequestExample
         builder = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("cdn.jsdelivr.net")
-            .WithMeasurementOptions(new PingOptions { Packets = 6 });
+            .WithOptions(new PingOptions { Packets = 6 });
         ConsoleHelpers.WriteJson(builder.Build(), "Request 4");
 
         builder = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Mtr)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new MtrOptions { Packets = 3 });
+            .WithOptions(new MtrOptions { Packets = 3 });
         ConsoleHelpers.WriteJson(builder.Build(), "Request 5");
 
         builder = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Dns)
             .WithTarget("cloudflare.com")
             .AddMagic("US")
-            .WithMeasurementOptions(new DnsOptions {
+            .WithOptions(new DnsOptions {
                 Query = new DnsQuery { Type = DnsQueryType.A },
                 Resolver = "8.8.8.8"
             });

--- a/Globalping.Examples/Examples/ExecuteDnsExample.cs
+++ b/Globalping.Examples/Examples/ExecuteDnsExample.cs
@@ -13,7 +13,7 @@ public static class ExecuteDnsExample
             .WithType(MeasurementType.Dns)
             .WithTarget("cloudflare.com")
             .AddMagic("US")
-            .WithMeasurementOptions(new DnsOptions
+            .WithOptions(new DnsOptions
             {
                 Query = new DnsQuery { Type = DnsQueryType.A },
                 Resolver = "8.8.8.8",

--- a/Globalping.Examples/Examples/ExecuteHttpExample.cs
+++ b/Globalping.Examples/Examples/ExecuteHttpExample.cs
@@ -11,7 +11,7 @@ public static class ExecuteHttpExample {
             .WithType(MeasurementType.Http)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new HttpOptions {
+            .WithOptions(new HttpOptions {
                 Request = new HttpRequestOptions {
                     Method = HttpRequestMethod.GET,
                     Path = "/"

--- a/Globalping.Examples/Examples/ExecuteMeasurementExample.cs
+++ b/Globalping.Examples/Examples/ExecuteMeasurementExample.cs
@@ -14,7 +14,7 @@ public static class ExecuteMeasurementExample
             .WithType(MeasurementType.Ping)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new PingOptions { Packets = 2 });
+            .WithOptions(new PingOptions { Packets = 2 });
 
         var request = builder.Build();
         request.InProgressUpdates = false;

--- a/Globalping.Examples/Examples/ExecuteMtrExample.cs
+++ b/Globalping.Examples/Examples/ExecuteMtrExample.cs
@@ -13,7 +13,7 @@ public static class ExecuteMtrExample
             .WithType(MeasurementType.Mtr)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new MtrOptions { Packets = 3 });
+            .WithOptions(new MtrOptions { Packets = 3 });
 
         var request = builder.Build();
         request.InProgressUpdates = false;

--- a/Globalping.Examples/Examples/ExecuteTracerouteExample.cs
+++ b/Globalping.Examples/Examples/ExecuteTracerouteExample.cs
@@ -13,7 +13,7 @@ public static class ExecuteTracerouteExample
             .WithType(MeasurementType.Traceroute)
             .WithTarget("cdn.jsdelivr.net")
             .AddMagic("Europe")
-            .WithMeasurementOptions(new TracerouteOptions());
+            .WithOptions(new TracerouteOptions());
 
         var request = builder.Build();
         request.InProgressUpdates = false;

--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -175,7 +175,7 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
 
             if (MeasurementOptions is not null)
             {
-                builder.WithMeasurementOptions(MeasurementOptions);
+                builder.WithOptions(MeasurementOptions);
             }
 
             var request = builder.Build();

--- a/Globalping.Tests/MeasurementRequestTests.cs
+++ b/Globalping.Tests/MeasurementRequestTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Xunit;
@@ -159,7 +160,7 @@ public sealed class MeasurementRequestTests
         var request = new MeasurementRequestBuilder()
             .WithType(MeasurementType.Ping)
             .WithTarget("example.com")
-            .WithMeasurementOptions(new PingOptions { Packets = 4 })
+            .WithOptions(new PingOptions { Packets = 4 })
             .WithLimit(3)
             .Build();
 
@@ -179,5 +180,23 @@ public sealed class MeasurementRequestTests
         var json = JsonSerializer.Serialize(request, JsonOptions);
 
         Assert.Contains("\"type\":\"ping\"", json);
+    }
+
+    [Theory]
+    [InlineData(typeof(PingOptions))]
+    [InlineData(typeof(MtrOptions))]
+    [InlineData(typeof(DnsOptions))]
+    [InlineData(typeof(HttpOptions))]
+    [InlineData(typeof(TracerouteOptions))]
+    public void BuilderWithOptionsAcceptsVariousTypes(Type optionType)
+    {
+        var options = (IMeasurementOptions)Activator.CreateInstance(optionType)!;
+        var request = new MeasurementRequestBuilder()
+            .WithType(MeasurementType.Ping)
+            .WithTarget("example.com")
+            .WithOptions(options)
+            .Build();
+
+        Assert.IsType(optionType, request.MeasurementOptions);
     }
 }

--- a/Globalping/MeasurementRequestBuilder.cs
+++ b/Globalping/MeasurementRequestBuilder.cs
@@ -97,11 +97,15 @@ public class MeasurementRequestBuilder
         return this;
     }
 
-    public MeasurementRequestBuilder WithMeasurementOptions(IMeasurementOptions options)
+    public MeasurementRequestBuilder WithOptions<TOptions>(TOptions options)
+        where TOptions : IMeasurementOptions
     {
         _request.MeasurementOptions = options;
         return this;
     }
+
+    public MeasurementRequestBuilder WithMeasurementOptions(IMeasurementOptions options)
+        => WithOptions(options);
 
     public MeasurementRequestBuilder WithInProgressUpdates(bool value = true)
     {


### PR DESCRIPTION
## Summary
- add `WithOptions<TOptions>` to MeasurementRequestBuilder
- update StartGlobalpingBaseCommand and examples to use the generic method
- test WithOptions for all option types

## Testing
- `dotnet test Globalping.Tests/Globalping.Tests.csproj -f net8.0`
- `dotnet test Globalping.PowerShell.Tests/Globalping.PowerShell.Tests.csproj -f net8.0`
- `dotnet build Globalping.sln`

------
https://chatgpt.com/codex/tasks/task_e_6887e32f2534832e850ee6b7a860e52b