### PR TITLE
Improve code coverage tests

### DIFF
--- a/Globalping.Tests/ConvertersAndExceptionsTests.cs
+++ b/Globalping.Tests/ConvertersAndExceptionsTests.cs
@@ -40,4 +40,34 @@ public class ConvertersAndExceptionsTests
         Assert.Equal(1, ex.UsageInfo.CreditsRemaining);
         Assert.Equal(2, ex.UsageInfo.RateLimitRemaining);
     }
+
+    [Fact]
+    public void GlobalpingApiException_DefaultsWhenNull()
+    {
+        var ex = new GlobalpingApiException(500, null, null);
+        Assert.Equal(500, ex.StatusCode);
+        Assert.NotNull(ex.Error);
+        Assert.NotNull(ex.UsageInfo);
+        Assert.Equal(string.Empty, ex.Error.Message);
+        Assert.NotEqual(string.Empty, ex.Message);
+    }
+
+    [Fact]
+    public void ErrorResponse_SerializeAndDeserialize()
+    {
+        var err = new ErrorResponse
+        {
+            Error = new ErrorDetails
+            {
+                Type = "bad_request",
+                Message = "wrong",
+                Params = new() { ["foo"] = "bar" }
+            }
+        };
+        var json = JsonSerializer.Serialize(err);
+        var result = JsonSerializer.Deserialize<ErrorResponse>(json);
+        Assert.NotNull(result);
+        Assert.Equal("bad_request", result!.Error.Type);
+        Assert.Equal("bar", result.Error.Params!["foo"]);
+    }
 }

--- a/Globalping.Tests/ParsingExtensionsAdditionalTests.cs
+++ b/Globalping.Tests/ParsingExtensionsAdditionalTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ParsingExtensionsAdditionalTests {
+    private static List<TracerouteHopResult> InvokeParseTracerouteRaw(string raw) {
+        var method = typeof(MeasurementResponseExtensions).GetMethod(
+            "ParseTracerouteRaw",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (List<TracerouteHopResult>)method!.Invoke(null, new object?[] { raw })!;
+    }
+
+    private static Dictionary<int, string> InvokeParseMtrRawHosts(string raw) {
+        var method = typeof(MeasurementResponseExtensions).GetMethod(
+            "ParseMtrRawHosts",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (Dictionary<int, string>)method!.Invoke(null, new object?[] { raw })!;
+    }
+
+    [Fact]
+    public void ParseTracerouteRaw_ParsesLines() {
+        var raw = "traceroute to example.com\n" +
+                  "1 router1 (1.1.1.1) 1.0 ms 2.0 ms 3.0 ms\n" +
+                  "2 router2 (2.2.2.2) 4.0 ms 5.0 ms\n";
+        var list = InvokeParseTracerouteRaw(raw);
+        Assert.Equal(2, list.Count);
+        Assert.Equal(1, list[0].Hop);
+        Assert.Equal("router1", list[0].Host);
+        Assert.Equal(3.0, list[0].Time3);
+    }
+
+    [Fact]
+    public void ParseMtrRawHosts_ParsesHosts() {
+        var raw = "header\nHost\n" +
+                  "1. AS123 router (1.1.1.1)\n" +
+                  "2. ??? waiting for reply\n" +
+                  "3. AS456 example (2.2.2.2)\n";
+        var dict = InvokeParseMtrRawHosts(raw);
+        Assert.Equal(3, dict.Count);
+        Assert.Equal("router", dict[1]);
+        Assert.Equal("waiting for reply", dict[2]);
+        Assert.Equal("example", dict[3]);
+    }
+}


### PR DESCRIPTION
## Summary
- add more unit tests for Globalping API classes
- test parsing helpers for traceroute and mtr
- ensure HTTP measurement builder ignores invalid URIs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68889a4d69b4832e8d07e70084e151a5