### PR TITLE
Increase test coverage

### DIFF
--- a/Globalping.Tests/MeasurementResponseConverterTests.cs
+++ b/Globalping.Tests/MeasurementResponseConverterTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class MeasurementResponseConverterTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    static MeasurementResponseConverterTests()
+    {
+        JsonOptions.Converters.Add(new JsonStringEnumConverter<MeasurementStatus>(JsonNamingPolicy.KebabCaseLower));
+        JsonOptions.Converters.Add(new JsonStringEnumConverter<TestStatus>(JsonNamingPolicy.KebabCaseLower));
+        JsonOptions.Converters.Add(new CountryCodeConverter());
+        JsonOptions.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+    }
+
+    [Fact]
+    public void UnknownType_YieldsNullOptions()
+    {
+        var json = """
+        {
+            "id": "1",
+            "type": "unknown",
+            "status": "finished",
+            "target": "example.com",
+            "probesCount": 0,
+            "measurementOptions": { "x": 1 }
+        }
+        """;
+        var result = JsonSerializer.Deserialize<MeasurementResponse>(json, JsonOptions);
+        Assert.NotNull(result);
+        Assert.Null(result!.MeasurementOptions);
+    }
+}

--- a/Globalping.Tests/ModelDefaultTests.cs
+++ b/Globalping.Tests/ModelDefaultTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ModelDefaultTests
+{
+    [Fact]
+    public void HttpRequestOptions_DefaultsAreSet()
+    {
+        var opts = new HttpRequestOptions();
+        Assert.Equal(HttpRequestMethod.HEAD, opts.Method);
+        opts.Headers["content-type"] = "text/plain";
+        Assert.True(opts.Headers.ContainsKey("Content-Type"));
+    }
+
+    [Fact]
+    public void HttpOptions_DefaultsAreSet()
+    {
+        var opts = new HttpOptions();
+        Assert.NotNull(opts.Request);
+        Assert.Equal(80, opts.Port);
+        Assert.Equal(HttpProtocol.HTTPS, opts.Protocol);
+        Assert.Equal(IpVersion.Four, opts.IpVersion);
+    }
+
+    [Fact]
+    public void DnsOptions_DefaultsAreSet()
+    {
+        var opts = new DnsOptions();
+        Assert.NotNull(opts.Query);
+        Assert.Equal(53, opts.Port);
+        Assert.Equal(DnsProtocol.UDP, opts.Protocol);
+        Assert.Equal(IpVersion.Four, opts.IpVersion);
+        Assert.False(opts.Trace);
+    }
+
+    [Fact]
+    public void TlsCertificate_RoundTripsJson()
+    {
+        var cert = new TlsCertificate
+        {
+            Protocol = "TLSv1.3",
+            CipherName = "AES",
+            Authorized = true,
+            CreatedAt = new DateTime(2024,1,1,0,0,0,DateTimeKind.Utc),
+            ExpiresAt = new DateTime(2025,1,1,0,0,0,DateTimeKind.Utc),
+            SerialNumber = "abc",
+            Fingerprint256 = "123"
+        };
+        var json = JsonSerializer.Serialize(cert);
+        var clone = JsonSerializer.Deserialize<TlsCertificate>(json);
+        Assert.Equal(cert.Protocol, clone!.Protocol);
+        Assert.Equal(cert.SerialNumber, clone.SerialNumber);
+        Assert.Equal(cert.Fingerprint256, clone.Fingerprint256);
+    }
+}

--- a/Globalping.Tests/ResultConverterCoverageTests.cs
+++ b/Globalping.Tests/ResultConverterCoverageTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using Xunit;
+
+namespace Globalping.Tests;
+
+public class ResultConverterCoverageTests
+{
+    [Fact]
+    public void InstanceMethods_DelegateToExtensions()
+    {
+        var result = new Result
+        {
+            Target = "example.com",
+            Probe = new Probe(),
+            Data = new ResultDetails()
+        };
+
+        Assert.Equal(ResultExtensions.ToPingTimings(result, "example.com").Count, result.ToPingTimings("example.com").Count);
+        Assert.Equal(ResultExtensions.ToPingTimings(result, result.Target).Count, result.ToPingTimings().Count);
+        Assert.Equal(ResultExtensions.ToTracerouteHops(result, "example.com").Count, result.ToTracerouteHops("example.com").Count);
+        Assert.Equal(ResultExtensions.ToTracerouteHops(result, result.Target).Count, result.ToTracerouteHops().Count);
+        Assert.Equal(ResultExtensions.ToMtrHops(result, "example.com").Count, result.ToMtrHops("example.com").Count);
+        Assert.Equal(ResultExtensions.ToMtrHops(result, result.Target).Count, result.ToMtrHops().Count);
+        Assert.Equal(ResultExtensions.ToDnsRecords(result, "example.com").Count, result.ToDnsRecords("example.com").Count);
+        Assert.Equal(ResultExtensions.ToDnsRecords(result, result.Target).Count, result.ToDnsRecords().Count);
+        Assert.Equal(ResultExtensions.ToHttpResponse(result, "example.com")?.StatusCode, result.ToHttpResponse("example.com")?.StatusCode);
+        Assert.Equal(ResultExtensions.ToHttpResponse(result, result.Target)?.StatusCode, result.ToHttpResponse()?.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- add model default tests
- ensure Result converters call extensions
- verify MeasurementResponseConverter handles unknown types

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6888b416d268832ea4cfcbbccbcca91a