### PR TITLE
Add XML docs for cmdlets and enforce strict help generation

### DIFF
--- a/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingLimitCommand.cs
@@ -6,22 +6,41 @@ namespace Globalping.PowerShell;
 
 /// <summary>Retrieve current API rate limits.</summary>
 /// <para>Calls the Globalping <c>/limits</c> endpoint and returns limit information.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Unauthenticated requests may report lower limits.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>Check remaining requests</summary>
-///   <code>Get-GlobalpingLimit</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Get-GlobalpingLimit</para>
+///   </code>
 ///   <para>Returns rate limit information for the anonymous user or provided API key.</para>
 /// </example>
+/// <example>
+///   <summary>Retrieve raw limit data</summary>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Get-GlobalpingLimit -Raw</para>
+///   </code>
+///   <para>Outputs the unprocessed <see cref="Limits"/> response.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsCommon.Get, "GlobalpingLimit")]
 [OutputType(typeof(LimitInfo))]
 [OutputType(typeof(Limits))]
 [OutputType(typeof(Credits))]
 public class GetGlobalpingLimitCommand : PSCmdlet {
     /// <summary>API key used for authenticated calls.</summary>
+    /// <para>Provide this to view limits associated with your account.</para>
     [Parameter]
     [Alias("Token")]
     public string? ApiKey { get; set; }
 
     /// <summary>Return the raw <see cref="Limits"/> object.</summary>
+    /// <para>Outputs the service response without flattening to <see cref="LimitInfo"/>.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }

--- a/Globalping.PowerShell/GetGlobalpingProbeCommand.cs
+++ b/Globalping.PowerShell/GetGlobalpingProbeCommand.cs
@@ -7,21 +7,40 @@ namespace Globalping.PowerShell;
 
 /// <summary>Retrieve currently online probes.</summary>
 /// <para>Calls the Globalping <c>/probes</c> endpoint and returns probe information.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Probe availability can change between requests.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>List probes</summary>
-///   <code>Get-GlobalpingProbe</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Get-GlobalpingProbe</para>
+///   </code>
 ///   <para>Outputs flattened probe objects describing each online probe.</para>
 /// </example>
+/// <example>
+///   <summary>Return raw probe objects</summary>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Get-GlobalpingProbe -Raw</para>
+///   </code>
+///   <para>Displays the unprocessed <see cref="Probes"/> response.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsCommon.Get, "GlobalpingProbe")]
 [OutputType(typeof(ProbeInfo))]
 [OutputType(typeof(Probes))]
 public class GetGlobalpingProbeCommand : PSCmdlet {
     /// <summary>API key used for authenticated calls.</summary>
+    /// <para>Include when accessing endpoints that require authentication.</para>
     [Parameter]
     [Alias("Token")]
     public string? ApiKey { get; set; }
 
     /// <summary>Return the raw <see cref="Probes"/> objects.</summary>
+    /// <para>Outputs the API response without conversion to <see cref="ProbeInfo"/>.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }

--- a/Globalping.PowerShell/Globalping.PowerShell.csproj
+++ b/Globalping.PowerShell/Globalping.PowerShell.csproj
@@ -22,6 +22,10 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 

--- a/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingBaseCommand.cs
@@ -14,17 +14,26 @@ namespace Globalping.PowerShell;
 /// and return structured results.</para>
 /// <para>The common parameters defined here control target host, probe
 /// selection and authentication.</para>
-/// <seealso href="https://github.com/EvotecIT/Globalping/tree/main/Globalping.Examples">Repository examples</seealso>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Measurements generate network traffic from remote probes.</description>
+///   </item>
+/// </list>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping/tree/main/Globalping.Examples" />
 /// <example>
 ///   <summary>Ping from Germany</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingPing -Target "example.com" -SimpleLocations "DE"</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingPing -Target "example.com" -SimpleLocations "DE"</para>
+///   </code>
 ///   <para>Runs a ping measurement from German probes.</para>
 /// </example>
 /// <example>
 ///   <summary>HTTP request with live updates</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates -WaitTime 60</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingHttp -Target "https://example.com" -Limit 3 -InProgressUpdates -WaitTime 60</para>
+///   </code>
 ///   <para>Requests three probes and streams intermediate results for up to one minute.</para>
 /// </example>
 public abstract class StartGlobalpingBaseCommand : PSCmdlet
@@ -34,15 +43,13 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
     /// </summary>
     protected abstract MeasurementType Type { get; }
 
-    /// <para>Target host names, IP addresses or URLs to test.</para>
-    /// <para>Each value is passed verbatim to the underlying
-    /// measurement API.</para>
+    /// <summary>Target host names, IP addresses or URLs to test.</summary>
+    /// <para>Each value is passed verbatim to the underlying measurement API.</para>
     [Parameter(Mandatory = true)]
     public string[] Target { get; set; } = Array.Empty<string>();
 
-    /// <para>Detailed location definitions for probes.</para>
-    /// <para>Each <see cref="LocationRequest"/> may specify city, country,
-    /// ASN or provider details.</para>
+    /// <summary>Detailed location definitions for probes.</summary>
+    /// <para>Each <see cref="LocationRequest"/> may specify city, country, ASN or provider details.</para>
     [Parameter]
     public LocationRequest[]? Locations { get; set; }
 
@@ -50,32 +57,29 @@ public abstract class StartGlobalpingBaseCommand : PSCmdlet
     [Parameter]
     public string? ReuseLocationsFromId { get; set; }
 
-    /// <para>Short location identifiers such as city or country codes.</para>
-    /// <para>Two-letter strings are treated as ISO country codes. Longer
-    /// values map to the "magic" location syntax used by the API.</para>
+    /// <summary>Short location identifiers such as city or country codes.</summary>
+    /// <para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</para>
     [Parameter]
     public string[]? SimpleLocations { get; set; }
 
-    /// <para>Maximum number of probes to use.</para>
-    /// <para>If omitted the cmdlet estimates a value based on provided
-    /// locations.</para>
+    /// <summary>Maximum number of probes to use.</summary>
+    /// <para>If omitted the cmdlet estimates a value based on provided locations.</para>
     [Parameter]
     [ValidateRange(1, 500)]
     public int? Limit { get; set; }
 
-    /// <para>Request progress updates while the measurement runs.</para>
-    /// <para>When set the API streams partial results that are written as they
-    /// arrive.</para>
+    /// <summary>Request progress updates while the measurement runs.</summary>
+    /// <para>When set the API streams partial results that are written as they arrive.</para>
     [Parameter]
     public SwitchParameter InProgressUpdates { get; set; }
 
-    /// <para>Time in seconds to wait for progress updates.</para>
+    /// <summary>Time in seconds to wait for progress updates.</summary>
     /// <para>Only applies when <see cref="InProgressUpdates"/> is specified.</para>
     [Parameter]
     [ValidateRange(1, int.MaxValue)]
     public int WaitTime { get; set; } = 150;
 
-    /// <para>API key used to authenticate with Globalping.</para>
+    /// <summary>API key used to authenticate with Globalping.</summary>
     /// <para>Anonymous requests may be rate limited.</para>
     [Parameter]
     [Alias("Token")]

--- a/Globalping.PowerShell/StartGlobalpingDnsCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingDnsCommand.cs
@@ -5,36 +5,46 @@ namespace Globalping.PowerShell;
 
 /// <summary>Start a DNS lookup using Globalping.</summary>
 /// <para>Queries DNS records from remote probes and converts them to <see cref="DnsRecordResult"/> objects.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>DNS caches may cause different probes to return varying results.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>Resolve A record</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingDns -Target "evotec.xyz"</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingDns -Target "evotec.xyz"</para>
+///   </code>
 ///   <para>Returns DNS records from available probes.</para>
 /// </example>
 /// <example>
 ///   <summary>Use custom resolver</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingDns -Target "cloudflare.com" -Options @{ Resolver = "8.8.8.8" }</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingDns -Target "cloudflare.com" -Options @{ Resolver = "8.8.8.8" }</para>
+///   </code>
 ///   <para>Sends the DNS query using the Google public resolver.</para>
 /// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingDns")]
 [OutputType(typeof(DnsRecordResult))]
 [OutputType(typeof(string))]
 [OutputType(typeof(MeasurementResponse))]
 public class StartGlobalpingDnsCommand : StartGlobalpingBaseCommand
 {
-    /// <para>Return the raw measurement response.</para>
+    /// <summary>Return the raw measurement response.</summary>
     /// <para>Use this switch to inspect the <see cref="MeasurementResponse"/> object without conversion.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
-    /// <para>Output DNS results in classic text form.</para>
+    /// <summary>Output DNS results in classic text form.</summary>
     /// <para>The original text returned by the resolver is emitted.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
-    /// <para>Additional DNS options for the request.</para>
+    /// <summary>Additional DNS options for the request.</summary>
     /// <para>Allows custom resolver, query type or trace options.</para>
     [Parameter]
     public DnsOptions? Options { get; set; }

--- a/Globalping.PowerShell/StartGlobalpingHttpCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingHttpCommand.cs
@@ -5,41 +5,51 @@ namespace Globalping.PowerShell;
 
 /// <summary>Start an HTTP request using Globalping.</summary>
 /// <para>Sends an HTTP request from remote probes and returns <see cref="HttpResponseResult"/> objects.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Requests are executed from remote probes and may trigger security alerts on the target.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>Fetch a webpage</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingHttp -Target "evotec.xyz" -SimpleLocations "Krakow+PL"</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingHttp -Target "evotec.xyz" -SimpleLocations "Krakow+PL"</para>
+///   </code>
 ///   <para>Returns HTTP response details from the Krakow probe.</para>
 /// </example>
 /// <example>
 ///   <summary>Headers only</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingHttp -Target "https://example.com" -HeadersOnly</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingHttp -Target "https://example.com" -HeadersOnly</para>
+///   </code>
 ///   <para>Outputs only the HTTP headers from each probe.</para>
 /// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingHttp")]
 [OutputType(typeof(HttpResponseResult))]
 [OutputType(typeof(string))]
 [OutputType(typeof(MeasurementResponse))]
 public class StartGlobalpingHttpCommand : StartGlobalpingBaseCommand
 {
-    /// <para>Return the raw measurement response.</para>
+    /// <summary>Return the raw measurement response.</summary>
     /// <para>The full <see cref="MeasurementResponse"/> is emitted without conversion.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
-    /// <para>Output HTTP results in classic text form.</para>
+    /// <summary>Output HTTP results in classic text form.</summary>
     /// <para>Each probe returns the textual output of the underlying HTTP tool.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
-    /// <para>Emit only HTTP headers from each response.</para>
+    /// <summary>Emit only HTTP headers from each response.</summary>
     /// <para>Ignores the body content from the probes.</para>
     [Parameter]
     public SwitchParameter HeadersOnly { get; set; }
 
-    /// <para>Additional HTTP options for the request.</para>
+    /// <summary>Additional HTTP options for the request.</summary>
     /// <para>Allows setting request method, headers or body.</para>
     [Parameter]
     public HttpOptions? Options { get; set; }

--- a/Globalping.PowerShell/StartGlobalpingMtrCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingMtrCommand.cs
@@ -5,36 +5,46 @@ namespace Globalping.PowerShell;
 
 /// <summary>Start an MTR (My Traceroute) measurement using Globalping.</summary>
 /// <para>Combines ping and traceroute information from multiple probes.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Some paths may change during the test, affecting hop statistics.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>Run MTR against a host</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingMtr -Target "evotec.xyz"</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingMtr -Target "evotec.xyz"</para>
+///   </code>
 ///   <para>Produces hop statistics for the target.</para>
 /// </example>
 /// <example>
 ///   <summary>Limit packets</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingMtr -Target "example.com" -Options @{ Packets = 3 }</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingMtr -Target "example.com" -Options @{ Packets = 3 }</para>
+///   </code>
 ///   <para>Configures the probe to send three packets per hop.</para>
 /// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingMtr")]
 [OutputType(typeof(MtrHopResult))]
 [OutputType(typeof(string))]
 [OutputType(typeof(MeasurementResponse))]
 public class StartGlobalpingMtrCommand : StartGlobalpingBaseCommand
 {
-    /// <para>Return the raw measurement response.</para>
+    /// <summary>Return the raw measurement response.</summary>
     /// <para>Useful when converting the result to custom objects.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
-    /// <para>Output MTR results in classic text form.</para>
+    /// <summary>Output MTR results in classic text form.</summary>
     /// <para>The text output mirrors the behaviour of the MTR command line tool.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
-    /// <para>Additional MTR options for the request.</para>
+    /// <summary>Additional MTR options for the request.</summary>
     /// <para>Use to configure packet count or other low level parameters.</para>
     [Parameter]
     public MtrOptions? Options { get; set; }

--- a/Globalping.PowerShell/StartGlobalpingPingCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingPingCommand.cs
@@ -6,42 +6,53 @@ namespace Globalping.PowerShell;
 /// <summary>Start a ping measurement using Globalping.</summary>
 /// <para>Instructs remote probes to send ICMP echo requests to the specified target.</para>
 /// <para>The cmdlet outputs <see cref="PingTimingResult"/> objects, raw results or classic text depending on the selected parameters.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Some networks block ICMP traffic which may affect results.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>Ping from multiple locations</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingPing -Target "evotec.xyz" -SimpleLocations "DE", "US"</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingPing -Target "evotec.xyz" -SimpleLocations "DE", "US"</para>
+///   </code>
 ///   <para>Runs ping from probes in Germany and the United States.</para>
 /// </example>
 /// <example>
 ///   <summary>Request five packets</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingPing -Target "example.com" -SimpleLocations "PL" -Options @{ Packets = 5 }</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingPing -Target "example.com" -SimpleLocations "PL" -Options @{ Packets = 5 }</para>
+///   </code>
 ///   <para>Uses <see cref="PingOptions"/> to set the packet count.</para>
 /// </example>
 /// <example>
 ///   <summary>Output classic text</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingPing -Target "example.com" -Classic</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingPing -Target "example.com" -Classic</para>
+///   </code>
 ///   <para>Displays the raw ping output returned by the probe.</para>
 /// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingPing")]
 [OutputType(typeof(PingTimingResult))]
 [OutputType(typeof(string))]
 [OutputType(typeof(MeasurementResponse))]
 public class StartGlobalpingPingCommand : StartGlobalpingBaseCommand
 {
-    /// <para>Return the unprocessed measurement response.</para>
+    /// <summary>Return the unprocessed measurement response.</summary>
     /// <para>When set the cmdlet outputs the <see cref="MeasurementResponse"/> object returned by the API.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
-    /// <para>Output ping results in the classic text format.</para>
+    /// <summary>Output ping results in the classic text format.</summary>
     /// <para>Each probe returns the textual output of its ping utility.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
-    /// <para>Additional ping options sent with the request.</para>
+    /// <summary>Additional ping options sent with the request.</summary>
     /// <para>Use this to configure packet count or other low level settings.</para>
     [Parameter]
     public PingOptions? Options { get; set; }

--- a/Globalping.PowerShell/StartGlobalpingTracerouteCommand.cs
+++ b/Globalping.PowerShell/StartGlobalpingTracerouteCommand.cs
@@ -5,36 +5,46 @@ namespace Globalping.PowerShell;
 
 /// <summary>Start a traceroute measurement using Globalping.</summary>
 /// <para>Collects hop information from remote probes with optional classic text output.</para>
+/// <list type="alertSet">
+///   <item>
+///     <term>Note</term>
+///     <description>Intermediate hops may drop packets, resulting in missing data.</description>
+///   </item>
+/// </list>
 /// <example>
 ///   <summary>Traceroute to a host</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingTraceroute -Target "evotec.xyz"</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingTraceroute -Target "evotec.xyz"</para>
+///   </code>
 ///   <para>Performs traceroute to the target host.</para>
 /// </example>
 /// <example>
 ///   <summary>Return raw output</summary>
-///   <prefix>PS> </prefix>
-///   <code>Start-GlobalpingTraceroute -Target "example.com" -Classic</code>
+///   <code>
+///     <para><prefix>PS&gt; </prefix>Start-GlobalpingTraceroute -Target "example.com" -Classic</para>
+///   </code>
 ///   <para>Writes the traceroute text produced by the probe.</para>
 /// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/" />
+/// <seealso href="https://github.com/EvotecIT/Globalping" />
 [Cmdlet(VerbsLifecycle.Start, "GlobalpingTraceroute")]
 [OutputType(typeof(TracerouteHopResult))]
 [OutputType(typeof(string))]
 [OutputType(typeof(MeasurementResponse))]
 public class StartGlobalpingTracerouteCommand : StartGlobalpingBaseCommand
 {
-    /// <para>Return the full measurement response.</para>
+    /// <summary>Return the full measurement response.</summary>
     /// <para>The object is not converted to individual hops.</para>
     [Parameter]
     [Alias("AsRaw")]
     public SwitchParameter Raw { get; set; }
 
-    /// <para>Output traceroute in classic text form.</para>
+    /// <summary>Output traceroute in classic text form.</summary>
     /// <para>Returns the text produced by the traceroute utility.</para>
     [Parameter]
     public SwitchParameter Classic { get; set; }
 
-    /// <para>Additional traceroute options for the request.</para>
+    /// <summary>Additional traceroute options for the request.</summary>
     /// <para>Allows packet size or protocol customization.</para>
     [Parameter]
     public TracerouteOptions? Options { get; set; }

--- a/Globalping/DnsRecordResult.cs
+++ b/Globalping/DnsRecordResult.cs
@@ -1,5 +1,6 @@
 namespace Globalping;
 
+/// <summary>DNS response information returned by a probe.</summary>
 public class DnsRecordResult
 {
     public string Target { get; set; } = string.Empty;

--- a/Globalping/HttpResponseResult.cs
+++ b/Globalping/HttpResponseResult.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 namespace Globalping;
 
+/// <summary>HTTP response details returned by a probe.</summary>
 public class HttpResponseResult
 {
     public string Target { get; set; } = string.Empty;

--- a/Globalping/MtrHopResult.cs
+++ b/Globalping/MtrHopResult.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 
 namespace Globalping;
 
+/// <summary>Hop statistics collected during an MTR measurement.</summary>
 public class MtrHopResult
 {
     public string Target { get; set; } = string.Empty;

--- a/Globalping/Responses/DnsAnswer.cs
+++ b/Globalping/Responses/DnsAnswer.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Serialization;
 namespace Globalping;
+
+/// <summary>Represents a single DNS answer record.</summary>
 public class DnsAnswer
 {
     [JsonPropertyName("name")]

--- a/Globalping/Responses/DnsTimings.cs
+++ b/Globalping/Responses/DnsTimings.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Serialization;
 namespace Globalping;
+
+/// <summary>Timing metrics for a DNS query.</summary>
 public class DnsTimings
 {
     [JsonPropertyName("total")]

--- a/Globalping/Responses/HttpTimings.cs
+++ b/Globalping/Responses/HttpTimings.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Serialization;
 namespace Globalping;
+
+/// <summary>Timing breakdown for an HTTP request.</summary>
 public class HttpTimings
 {
     [JsonPropertyName("total")]

--- a/Globalping/Responses/MeasurementResponse.cs
+++ b/Globalping/Responses/MeasurementResponse.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>Full response returned after creating a measurement.</summary>
 [JsonConverter(typeof(MeasurementResponseConverter))]
 public class MeasurementResponse {
     [JsonPropertyName("id")]

--- a/Globalping/Responses/Result.cs
+++ b/Globalping/Responses/Result.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>Represents the outcome from a single probe.</summary>
 public partial class Result {
     [JsonIgnore]
     public string Target { get; set; } = string.Empty;

--- a/Globalping/Responses/ResultDetails.cs
+++ b/Globalping/Responses/ResultDetails.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Globalping;
 
+/// <summary>Detailed data returned for a probe result.</summary>
 public class ResultDetails {
     [JsonPropertyName("status")]
     public TestStatus Status { get; set; }

--- a/Globalping/Responses/Stats.cs
+++ b/Globalping/Responses/Stats.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 namespace Globalping;
 
+/// <summary>Statistical summary for measurement results.</summary>
 public class Stats {
     [JsonPropertyName("min")]
     public double? Min { get; set; }

--- a/Globalping/Responses/TlsCertificate.cs
+++ b/Globalping/Responses/TlsCertificate.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Text.Json.Serialization;
 namespace Globalping;
+
+/// <summary>TLS certificate details reported by a probe.</summary>
 public class TlsCertificate
 {
     [JsonPropertyName("protocol")]

--- a/Globalping/Responses/TlsCertificateIssuer.cs
+++ b/Globalping/Responses/TlsCertificateIssuer.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Serialization;
 namespace Globalping;
+
+/// <summary>Issuer information for a TLS certificate.</summary>
 public class TlsCertificateIssuer
 {
     [JsonPropertyName("C")]

--- a/Globalping/Responses/TlsCertificateSubject.cs
+++ b/Globalping/Responses/TlsCertificateSubject.cs
@@ -1,5 +1,7 @@
 using System.Text.Json.Serialization;
 namespace Globalping;
+
+/// <summary>Subject information for a TLS certificate.</summary>
 public class TlsCertificateSubject
 {
     [JsonPropertyName("CN")]

--- a/Globalping/TracerouteHopResult.cs
+++ b/Globalping/TracerouteHopResult.cs
@@ -1,5 +1,6 @@
 namespace Globalping;
 
+/// <summary>Represents a single hop in a traceroute measurement.</summary>
 public class TracerouteHopResult
 {
     public string Target { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- document all PowerShell cmdlets with summaries, examples, notes and links
- describe complex response types for help generation
- enable strict XmlDoc2CmdletDoc processing

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689659f199c4832ea107ace11dacd651