### PR TITLE
Use PowerForge native documentation

### DIFF
--- a/Globalping.PowerShell/Globalping.PowerShell.csproj
+++ b/Globalping.PowerShell/Globalping.PowerShell.csproj
@@ -17,12 +17,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -48,20 +44,6 @@
     <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
         <Delete Files="$(OutDir)System.Management.Automation.dll" />
         <Delete Files="$(OutDir)System.Management.dll" />
-    </Target>
-
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
-            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
-            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
     </Target>
 
     <ItemGroup>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -78,7 +78,7 @@ Build-Module -ModuleName 'Globalping' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
@@ -99,8 +99,8 @@ Build-Module -ModuleName 'Globalping' {
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $true
-        NETBinaryModuleDocumenation       = $true
+        RefreshPSD1Only                   = $false
+        NETBinaryModuleDocumentation      = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Docs/Get-GlobalpingLimit.md
+++ b/Module/Docs/Get-GlobalpingLimit.md
@@ -1,0 +1,92 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Get-GlobalpingLimit
+## SYNOPSIS
+Retrieve current API rate limits.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-GlobalpingLimit [-ApiKey <string>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Calls the Globalping /limits endpoint and returns limit information.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-GlobalpingLimit
+```
+
+Returns rate limit information for the anonymous user or provided API key.
+
+### EXAMPLE 2
+```powershell
+PS> Get-GlobalpingLimit -Raw
+```
+
+Outputs the unprocessed Limits response.
+
+## PARAMETERS
+
+### -ApiKey
+Provide this to view limits associated with your account.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Outputs the service response without flattening to LimitInfo.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.LimitInfo`
+- `Globalping.Limits`
+- `Globalping.Credits`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+Unauthenticated requests may report lower limits.

--- a/Module/Docs/Get-GlobalpingProbe.md
+++ b/Module/Docs/Get-GlobalpingProbe.md
@@ -1,0 +1,91 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Get-GlobalpingProbe
+## SYNOPSIS
+Retrieve currently online probes.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-GlobalpingProbe [-ApiKey <string>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Calls the Globalping /probes endpoint and returns probe information.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-GlobalpingProbe
+```
+
+Outputs flattened probe objects describing each online probe.
+
+### EXAMPLE 2
+```powershell
+PS> Get-GlobalpingProbe -Raw
+```
+
+Displays the unprocessed Probes response.
+
+## PARAMETERS
+
+### -ApiKey
+Include when accessing endpoints that require authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Outputs the API response without conversion to ProbeInfo.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.ProbeInfo`
+- `Globalping.Probes`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+Probe availability can change between requests.

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -1,0 +1,32 @@
+---
+Module Name: Globalping
+Module Guid: a587d150-7ab5-47da-ae3a-3bb879e2c07f
+Download Help Link: https://github.com/EvotecIT/Globalping
+Help Version: 1.0.3
+Locale: en-US
+---
+# Globalping Module
+## Description
+Module using globaling.net API to ping any host globally and return results from multiple locations.
+
+## Globalping Cmdlets
+### [Get-GlobalpingLimit](Get-GlobalpingLimit.md)
+Retrieve current API rate limits.
+
+### [Get-GlobalpingProbe](Get-GlobalpingProbe.md)
+Retrieve currently online probes.
+
+### [Start-GlobalpingDns](Start-GlobalpingDns.md)
+Start a DNS lookup using Globalping.
+
+### [Start-GlobalpingHttp](Start-GlobalpingHttp.md)
+Start an HTTP request using Globalping.
+
+### [Start-GlobalpingMtr](Start-GlobalpingMtr.md)
+Start an MTR (My Traceroute) measurement using Globalping.
+
+### [Start-GlobalpingPing](Start-GlobalpingPing.md)
+Start a ping measurement using Globalping.
+
+### [Start-GlobalpingTraceroute](Start-GlobalpingTraceroute.md)
+Start a traceroute measurement using Globalping.

--- a/Module/Docs/Start-GlobalpingDns.md
+++ b/Module/Docs/Start-GlobalpingDns.md
@@ -11,7 +11,7 @@ Start a DNS lookup using Globalping.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Start-GlobalpingDns -Target <string[]> [-Raw] [-Classic] [-Options <DnsOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+Start-GlobalpingDns -Target <string[]> [-Raw] [-Classic] [-Options <DnsOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <Int32>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ Sends the DNS query using the Google public resolver.
 ## PARAMETERS
 
 ### -ApiKey
-{{ Fill ApiKey Description }}
+Anonymous requests may be rate limited.
 
 ```yaml
 Type: String
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### -InProgressUpdates
-{{ Fill InProgressUpdates Description }}
+When set the API streams partial results that are written as they arrive.
 
 ```yaml
 Type: SwitchParameter
@@ -84,10 +84,10 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-{{ Fill Limit Description }}
+If omitted the cmdlet estimates a value based on provided locations.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -Locations
-{{ Fill Locations Description }}
+Each LocationRequest may specify city, country, ASN or provider details.
 
 ```yaml
 Type: LocationRequest[]
@@ -148,7 +148,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReuseLocationsFromId
-{{ Fill ReuseLocationsFromId Description }}
+Reuse probe locations from a previous measurement.
 
 ```yaml
 Type: String
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 ```
 
 ### -SimpleLocations
-{{ Fill SimpleLocations Description }}
+Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.
 
 ```yaml
 Type: String[]
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-{{ Fill Target Description }}
+Each value is passed verbatim to the underlying measurement API.
 
 ```yaml
 Type: String[]
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 ```
 
 ### -WaitTime
-{{ Fill WaitTime Description }}
+Only applies when InProgressUpdates is specified.
 
 ```yaml
 Type: Int32

--- a/Module/Docs/Start-GlobalpingDns.md
+++ b/Module/Docs/Start-GlobalpingDns.md
@@ -1,0 +1,236 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Start-GlobalpingDns
+## SYNOPSIS
+Start a DNS lookup using Globalping.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-GlobalpingDns -Target <string[]> [-Raw] [-Classic] [-Options <DnsOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Queries DNS records from remote probes and converts them to DnsRecordResult objects.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Start-GlobalpingDns -Target "evotec.xyz"
+```
+
+Returns DNS records from available probes.
+
+### EXAMPLE 2
+```powershell
+PS> Start-GlobalpingDns -Target "cloudflare.com" -Options @{ Resolver = "8.8.8.8" }
+```
+
+Sends the DNS query using the Google public resolver.
+
+## PARAMETERS
+
+### -ApiKey
+{{ Fill ApiKey Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Classic
+The original text returned by the resolver is emitted.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InProgressUpdates
+{{ Fill InProgressUpdates Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+{{ Fill Limit Description }}
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Locations
+{{ Fill Locations Description }}
+
+```yaml
+Type: LocationRequest[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Options
+Allows custom resolver, query type or trace options.
+
+```yaml
+Type: DnsOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Use this switch to inspect the MeasurementResponse object without conversion.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReuseLocationsFromId
+{{ Fill ReuseLocationsFromId Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SimpleLocations
+{{ Fill SimpleLocations Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+{{ Fill Target Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitTime
+{{ Fill WaitTime Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.DnsRecordResult`
+- `System.String`
+- `Globalping.MeasurementResponse`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+DNS caches may cause different probes to return varying results.

--- a/Module/Docs/Start-GlobalpingHttp.md
+++ b/Module/Docs/Start-GlobalpingHttp.md
@@ -11,7 +11,7 @@ Start an HTTP request using Globalping.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Start-GlobalpingHttp -Target <string[]> [-Raw] [-Classic] [-HeadersOnly] [-Options <HttpOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+Start-GlobalpingHttp -Target <string[]> [-Raw] [-Classic] [-HeadersOnly] [-Options <HttpOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <Int32>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ Outputs only the HTTP headers from each probe.
 ## PARAMETERS
 
 ### -ApiKey
-{{ Fill ApiKey Description }}
+Anonymous requests may be rate limited.
 
 ```yaml
 Type: String
@@ -84,7 +84,7 @@ Accept wildcard characters: False
 ```
 
 ### -InProgressUpdates
-{{ Fill InProgressUpdates Description }}
+When set the API streams partial results that are written as they arrive.
 
 ```yaml
 Type: SwitchParameter
@@ -100,10 +100,10 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-{{ Fill Limit Description }}
+If omitted the cmdlet estimates a value based on provided locations.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -116,7 +116,7 @@ Accept wildcard characters: False
 ```
 
 ### -Locations
-{{ Fill Locations Description }}
+Each LocationRequest may specify city, country, ASN or provider details.
 
 ```yaml
 Type: LocationRequest[]
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReuseLocationsFromId
-{{ Fill ReuseLocationsFromId Description }}
+Reuse probe locations from a previous measurement.
 
 ```yaml
 Type: String
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -SimpleLocations
-{{ Fill SimpleLocations Description }}
+Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.
 
 ```yaml
 Type: String[]
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-{{ Fill Target Description }}
+Each value is passed verbatim to the underlying measurement API.
 
 ```yaml
 Type: String[]
@@ -212,7 +212,7 @@ Accept wildcard characters: False
 ```
 
 ### -WaitTime
-{{ Fill WaitTime Description }}
+Only applies when InProgressUpdates is specified.
 
 ```yaml
 Type: Int32

--- a/Module/Docs/Start-GlobalpingHttp.md
+++ b/Module/Docs/Start-GlobalpingHttp.md
@@ -1,0 +1,252 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Start-GlobalpingHttp
+## SYNOPSIS
+Start an HTTP request using Globalping.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-GlobalpingHttp -Target <string[]> [-Raw] [-Classic] [-HeadersOnly] [-Options <HttpOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Sends an HTTP request from remote probes and returns HttpResponseResult objects.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Start-GlobalpingHttp -Target "evotec.xyz" -SimpleLocations "Krakow+PL"
+```
+
+Returns HTTP response details from the Krakow probe.
+
+### EXAMPLE 2
+```powershell
+PS> Start-GlobalpingHttp -Target "https://example.com" -HeadersOnly
+```
+
+Outputs only the HTTP headers from each probe.
+
+## PARAMETERS
+
+### -ApiKey
+{{ Fill ApiKey Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Classic
+Each probe returns the textual output of the underlying HTTP tool.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HeadersOnly
+Ignores the body content from the probes.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InProgressUpdates
+{{ Fill InProgressUpdates Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+{{ Fill Limit Description }}
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Locations
+{{ Fill Locations Description }}
+
+```yaml
+Type: LocationRequest[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Options
+Allows setting request method, headers or body.
+
+```yaml
+Type: HttpOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+The full MeasurementResponse is emitted without conversion.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReuseLocationsFromId
+{{ Fill ReuseLocationsFromId Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SimpleLocations
+{{ Fill SimpleLocations Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+{{ Fill Target Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitTime
+{{ Fill WaitTime Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.HttpResponseResult`
+- `System.String`
+- `Globalping.MeasurementResponse`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+Requests are executed from remote probes and may trigger security alerts on the target.

--- a/Module/Docs/Start-GlobalpingMtr.md
+++ b/Module/Docs/Start-GlobalpingMtr.md
@@ -11,7 +11,7 @@ Start an MTR (My Traceroute) measurement using Globalping.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Start-GlobalpingMtr -Target <string[]> [-Raw] [-Classic] [-Options <MtrOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+Start-GlobalpingMtr -Target <string[]> [-Raw] [-Classic] [-Options <MtrOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <Int32>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ Configures the probe to send three packets per hop.
 ## PARAMETERS
 
 ### -ApiKey
-{{ Fill ApiKey Description }}
+Anonymous requests may be rate limited.
 
 ```yaml
 Type: String
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### -InProgressUpdates
-{{ Fill InProgressUpdates Description }}
+When set the API streams partial results that are written as they arrive.
 
 ```yaml
 Type: SwitchParameter
@@ -84,10 +84,10 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-{{ Fill Limit Description }}
+If omitted the cmdlet estimates a value based on provided locations.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -Locations
-{{ Fill Locations Description }}
+Each LocationRequest may specify city, country, ASN or provider details.
 
 ```yaml
 Type: LocationRequest[]
@@ -148,7 +148,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReuseLocationsFromId
-{{ Fill ReuseLocationsFromId Description }}
+Reuse probe locations from a previous measurement.
 
 ```yaml
 Type: String
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 ```
 
 ### -SimpleLocations
-{{ Fill SimpleLocations Description }}
+Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.
 
 ```yaml
 Type: String[]
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-{{ Fill Target Description }}
+Each value is passed verbatim to the underlying measurement API.
 
 ```yaml
 Type: String[]
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 ```
 
 ### -WaitTime
-{{ Fill WaitTime Description }}
+Only applies when InProgressUpdates is specified.
 
 ```yaml
 Type: Int32

--- a/Module/Docs/Start-GlobalpingMtr.md
+++ b/Module/Docs/Start-GlobalpingMtr.md
@@ -1,0 +1,236 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Start-GlobalpingMtr
+## SYNOPSIS
+Start an MTR (My Traceroute) measurement using Globalping.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-GlobalpingMtr -Target <string[]> [-Raw] [-Classic] [-Options <MtrOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Combines ping and traceroute information from multiple probes.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Start-GlobalpingMtr -Target "evotec.xyz"
+```
+
+Produces hop statistics for the target.
+
+### EXAMPLE 2
+```powershell
+PS> Start-GlobalpingMtr -Target "example.com" -Options @{ Packets = 3 }
+```
+
+Configures the probe to send three packets per hop.
+
+## PARAMETERS
+
+### -ApiKey
+{{ Fill ApiKey Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Classic
+The text output mirrors the behaviour of the MTR command line tool.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InProgressUpdates
+{{ Fill InProgressUpdates Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+{{ Fill Limit Description }}
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Locations
+{{ Fill Locations Description }}
+
+```yaml
+Type: LocationRequest[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Options
+Use to configure packet count or other low level parameters.
+
+```yaml
+Type: MtrOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+Useful when converting the result to custom objects.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReuseLocationsFromId
+{{ Fill ReuseLocationsFromId Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SimpleLocations
+{{ Fill SimpleLocations Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+{{ Fill Target Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitTime
+{{ Fill WaitTime Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.MtrHopResult`
+- `System.String`
+- `Globalping.MeasurementResponse`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+Some paths may change during the test, affecting hop statistics.

--- a/Module/Docs/Start-GlobalpingPing.md
+++ b/Module/Docs/Start-GlobalpingPing.md
@@ -1,0 +1,245 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Start-GlobalpingPing
+## SYNOPSIS
+Start a ping measurement using Globalping.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-GlobalpingPing -Target <string[]> [-Raw] [-Classic] [-Options <PingOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Instructs remote probes to send ICMP echo requests to the specified target.
+
+The cmdlet outputs PingTimingResult objects, raw results or classic text depending on the selected parameters.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Start-GlobalpingPing -Target "evotec.xyz" -SimpleLocations "DE", "US"
+```
+
+Runs ping from probes in Germany and the United States.
+
+### EXAMPLE 2
+```powershell
+PS> Start-GlobalpingPing -Target "example.com" -SimpleLocations "PL" -Options @{ Packets = 5 }
+```
+
+Uses PingOptions to set the packet count.
+
+### EXAMPLE 3
+```powershell
+PS> Start-GlobalpingPing -Target "example.com" -Classic
+```
+
+Displays the raw ping output returned by the probe.
+
+## PARAMETERS
+
+### -ApiKey
+{{ Fill ApiKey Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Classic
+Each probe returns the textual output of its ping utility.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InProgressUpdates
+{{ Fill InProgressUpdates Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+{{ Fill Limit Description }}
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Locations
+{{ Fill Locations Description }}
+
+```yaml
+Type: LocationRequest[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Options
+Use this to configure packet count or other low level settings.
+
+```yaml
+Type: PingOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+When set the cmdlet outputs the MeasurementResponse object returned by the API.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReuseLocationsFromId
+{{ Fill ReuseLocationsFromId Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SimpleLocations
+{{ Fill SimpleLocations Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+{{ Fill Target Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitTime
+{{ Fill WaitTime Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.PingTimingResult`
+- `System.String`
+- `Globalping.MeasurementResponse`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+Some networks block ICMP traffic which may affect results.

--- a/Module/Docs/Start-GlobalpingPing.md
+++ b/Module/Docs/Start-GlobalpingPing.md
@@ -11,7 +11,7 @@ Start a ping measurement using Globalping.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Start-GlobalpingPing -Target <string[]> [-Raw] [-Classic] [-Options <PingOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+Start-GlobalpingPing -Target <string[]> [-Raw] [-Classic] [-Options <PingOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <Int32>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,7 +45,7 @@ Displays the raw ping output returned by the probe.
 ## PARAMETERS
 
 ### -ApiKey
-{{ Fill ApiKey Description }}
+Anonymous requests may be rate limited.
 
 ```yaml
 Type: String
@@ -77,7 +77,7 @@ Accept wildcard characters: False
 ```
 
 ### -InProgressUpdates
-{{ Fill InProgressUpdates Description }}
+When set the API streams partial results that are written as they arrive.
 
 ```yaml
 Type: SwitchParameter
@@ -93,10 +93,10 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-{{ Fill Limit Description }}
+If omitted the cmdlet estimates a value based on provided locations.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -Locations
-{{ Fill Locations Description }}
+Each LocationRequest may specify city, country, ASN or provider details.
 
 ```yaml
 Type: LocationRequest[]
@@ -157,7 +157,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReuseLocationsFromId
-{{ Fill ReuseLocationsFromId Description }}
+Reuse probe locations from a previous measurement.
 
 ```yaml
 Type: String
@@ -173,7 +173,7 @@ Accept wildcard characters: False
 ```
 
 ### -SimpleLocations
-{{ Fill SimpleLocations Description }}
+Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.
 
 ```yaml
 Type: String[]
@@ -189,7 +189,7 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-{{ Fill Target Description }}
+Each value is passed verbatim to the underlying measurement API.
 
 ```yaml
 Type: String[]
@@ -205,7 +205,7 @@ Accept wildcard characters: False
 ```
 
 ### -WaitTime
-{{ Fill WaitTime Description }}
+Only applies when InProgressUpdates is specified.
 
 ```yaml
 Type: Int32

--- a/Module/Docs/Start-GlobalpingTraceroute.md
+++ b/Module/Docs/Start-GlobalpingTraceroute.md
@@ -11,7 +11,7 @@ Start a traceroute measurement using Globalping.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Start-GlobalpingTraceroute -Target <string[]> [-Raw] [-Classic] [-Options <TracerouteOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+Start-GlobalpingTraceroute -Target <string[]> [-Raw] [-Classic] [-Options <TracerouteOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <Int32>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,7 +36,7 @@ Writes the traceroute text produced by the probe.
 ## PARAMETERS
 
 ### -ApiKey
-{{ Fill ApiKey Description }}
+Anonymous requests may be rate limited.
 
 ```yaml
 Type: String
@@ -68,7 +68,7 @@ Accept wildcard characters: False
 ```
 
 ### -InProgressUpdates
-{{ Fill InProgressUpdates Description }}
+When set the API streams partial results that are written as they arrive.
 
 ```yaml
 Type: SwitchParameter
@@ -84,10 +84,10 @@ Accept wildcard characters: False
 ```
 
 ### -Limit
-{{ Fill Limit Description }}
+If omitted the cmdlet estimates a value based on provided locations.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -100,7 +100,7 @@ Accept wildcard characters: False
 ```
 
 ### -Locations
-{{ Fill Locations Description }}
+Each LocationRequest may specify city, country, ASN or provider details.
 
 ```yaml
 Type: LocationRequest[]
@@ -148,7 +148,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReuseLocationsFromId
-{{ Fill ReuseLocationsFromId Description }}
+Reuse probe locations from a previous measurement.
 
 ```yaml
 Type: String
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 ```
 
 ### -SimpleLocations
-{{ Fill SimpleLocations Description }}
+Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.
 
 ```yaml
 Type: String[]
@@ -180,7 +180,7 @@ Accept wildcard characters: False
 ```
 
 ### -Target
-{{ Fill Target Description }}
+Each value is passed verbatim to the underlying measurement API.
 
 ```yaml
 Type: String[]
@@ -196,7 +196,7 @@ Accept wildcard characters: False
 ```
 
 ### -WaitTime
-{{ Fill WaitTime Description }}
+Only applies when InProgressUpdates is specified.
 
 ```yaml
 Type: Int32

--- a/Module/Docs/Start-GlobalpingTraceroute.md
+++ b/Module/Docs/Start-GlobalpingTraceroute.md
@@ -1,0 +1,236 @@
+---
+external help file: Globalping-help.xml
+Module Name: Globalping
+online version: https://github.com/EvotecIT/Globalping
+schema: 2.0.0
+---
+# Start-GlobalpingTraceroute
+## SYNOPSIS
+Start a traceroute measurement using Globalping.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Start-GlobalpingTraceroute -Target <string[]> [-Raw] [-Classic] [-Options <TracerouteOptions>] [-Locations <LocationRequest[]>] [-ReuseLocationsFromId <string>] [-SimpleLocations <string[]>] [-Limit <int>] [-InProgressUpdates] [-WaitTime <int>] [-ApiKey <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Collects hop information from remote probes with optional classic text output.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Start-GlobalpingTraceroute -Target "evotec.xyz"
+```
+
+Performs traceroute to the target host.
+
+### EXAMPLE 2
+```powershell
+PS> Start-GlobalpingTraceroute -Target "example.com" -Classic
+```
+
+Writes the traceroute text produced by the probe.
+
+## PARAMETERS
+
+### -ApiKey
+{{ Fill ApiKey Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Token
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Classic
+Returns the text produced by the traceroute utility.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InProgressUpdates
+{{ Fill InProgressUpdates Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+{{ Fill Limit Description }}
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Locations
+{{ Fill Locations Description }}
+
+```yaml
+Type: LocationRequest[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Options
+Allows packet size or protocol customization.
+
+```yaml
+Type: TracerouteOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+The object is not converted to individual hops.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: AsRaw
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReuseLocationsFromId
+{{ Fill ReuseLocationsFromId Description }}
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SimpleLocations
+{{ Fill SimpleLocations Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Target
+{{ Fill Target Description }}
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitTime
+{{ Fill WaitTime Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `Globalping.TracerouteHopResult`
+- `System.String`
+- `Globalping.MeasurementResponse`
+
+## RELATED LINKS
+
+- [https://learn.microsoft.com/powershell/](https://learn.microsoft.com/powershell/)
+- [https://github.com/EvotecIT/Globalping](https://github.com/EvotecIT/Globalping)
+
+## NOTES
+
+### Note
+
+Intermediate hops may drop packets, resulting in missing data.

--- a/Module/Globalping.psd1
+++ b/Module/Globalping.psd1
@@ -4,17 +4,21 @@
     CmdletsToExport      = @('Get-GlobalpingLimit', 'Get-GlobalpingProbe', 'Start-GlobalpingDns', 'Start-GlobalpingHttp', 'Start-GlobalpingMtr', 'Start-GlobalpingPing', 'Start-GlobalpingTraceroute')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
-    Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'Module using globaling.net API to ping any host globally and return results from multiple locations.'
     FunctionsToExport    = @()
     GUID                 = 'a587d150-7ab5-47da-ae3a-3bb879e2c07f'
-    ModuleVersion        = '1.0.2'
+    ModuleVersion        = '1.0.3'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
-            ProjectUri = 'https://github.com/EvotecIT/Globalping'
-            Tags       = @('ping', 'globalping', 'global', 'pinging', 'network', 'networking', 'internet')
+            ProjectUri                 = 'https://github.com/EvotecIT/Globalping'
+            Tags                       = @('ping', 'globalping', 'global', 'pinging', 'network', 'networking', 'internet')
+            RequireLicenseAcceptance   = $false
+            ExternalModuleDependencies = @()
         }
     }
     RootModule           = 'Globalping.psm1'
+    RequiredModules      = @()
+    ScriptsToProcess     = @()
 }

--- a/Module/en-US/Globalping-help.xml
+++ b/Module/en-US/Globalping-help.xml
@@ -1,0 +1,1978 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-GlobalpingLimit</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>GlobalpingLimit</command:noun>
+      <maml:description>
+        <maml:para>Retrieve current API rate limits.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Calls the Globalping /limits endpoint and returns limit information.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-GlobalpingLimit</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>Provide this to view limits associated with your account.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Outputs the service response without flattening to LimitInfo.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para>Provide this to view limits associated with your account.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Outputs the service response without flattening to LimitInfo.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.LimitInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.Limits</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.Credits</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Unauthenticated requests may report lower limits.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Check remaining requests</maml:title>
+        <dev:code>PS&gt; Get-GlobalpingLimit</dev:code>
+        <dev:remarks>
+          <maml:para>Returns rate limit information for the anonymous user or provided API key.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Retrieve raw limit data</maml:title>
+        <dev:code>PS&gt; Get-GlobalpingLimit -Raw</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs the unprocessed Limits response.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-GlobalpingProbe</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>GlobalpingProbe</command:noun>
+      <maml:description>
+        <maml:para>Retrieve currently online probes.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Calls the Globalping /probes endpoint and returns probe information.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-GlobalpingProbe</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para>Include when accessing endpoints that require authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Outputs the API response without conversion to ProbeInfo.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para>Include when accessing endpoints that require authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Outputs the API response without conversion to ProbeInfo.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.ProbeInfo</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.Probes</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Probe availability can change between requests.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List probes</maml:title>
+        <dev:code>PS&gt; Get-GlobalpingProbe</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs flattened probe objects describing each online probe.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Return raw probe objects</maml:title>
+        <dev:code>PS&gt; Get-GlobalpingProbe -Raw</dev:code>
+        <dev:remarks>
+          <maml:para>Displays the unprocessed Probes response.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-GlobalpingDns</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>GlobalpingDns</command:noun>
+      <maml:description>
+        <maml:para>Start a DNS lookup using Globalping.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Queries DNS records from remote probes and converts them to DnsRecordResult objects.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-GlobalpingDns</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Classic</maml:name>
+          <maml:description>
+            <maml:para>The original text returned by the resolver is emitted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>InProgressUpdates</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Locations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+          <dev:type>
+            <maml:name>LocationRequest[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Options</maml:name>
+          <maml:description>
+            <maml:para>Allows custom resolver, query type or trace options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>DnsOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Use this switch to inspect the MeasurementResponse object without conversion.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReuseLocationsFromId</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SimpleLocations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitTime</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Classic</maml:name>
+        <maml:description>
+          <maml:para>The original text returned by the resolver is emitted.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>InProgressUpdates</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Locations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+        <dev:type>
+          <maml:name>LocationRequest[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Options</maml:name>
+        <maml:description>
+          <maml:para>Allows custom resolver, query type or trace options.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DnsOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>DnsOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Use this switch to inspect the MeasurementResponse object without conversion.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReuseLocationsFromId</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SimpleLocations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitTime</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.DnsRecordResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.MeasurementResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>DNS caches may cause different probes to return varying results.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Resolve A record</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingDns -Target "evotec.xyz"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns DNS records from available probes.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Use custom resolver</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingDns -Target "cloudflare.com" -Options @{ Resolver = "8.8.8.8" }</dev:code>
+        <dev:remarks>
+          <maml:para>Sends the DNS query using the Google public resolver.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-GlobalpingHttp</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>GlobalpingHttp</command:noun>
+      <maml:description>
+        <maml:para>Start an HTTP request using Globalping.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Sends an HTTP request from remote probes and returns HttpResponseResult objects.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-GlobalpingHttp</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Classic</maml:name>
+          <maml:description>
+            <maml:para>Each probe returns the textual output of the underlying HTTP tool.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>HeadersOnly</maml:name>
+          <maml:description>
+            <maml:para>Ignores the body content from the probes.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>InProgressUpdates</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Locations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+          <dev:type>
+            <maml:name>LocationRequest[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Options</maml:name>
+          <maml:description>
+            <maml:para>Allows setting request method, headers or body.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">HttpOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>HttpOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>The full MeasurementResponse is emitted without conversion.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReuseLocationsFromId</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SimpleLocations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitTime</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Classic</maml:name>
+        <maml:description>
+          <maml:para>Each probe returns the textual output of the underlying HTTP tool.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>HeadersOnly</maml:name>
+        <maml:description>
+          <maml:para>Ignores the body content from the probes.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>InProgressUpdates</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Locations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+        <dev:type>
+          <maml:name>LocationRequest[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Options</maml:name>
+        <maml:description>
+          <maml:para>Allows setting request method, headers or body.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">HttpOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>HttpOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>The full MeasurementResponse is emitted without conversion.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReuseLocationsFromId</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SimpleLocations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitTime</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.HttpResponseResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.MeasurementResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Requests are executed from remote probes and may trigger security alerts on the target.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Fetch a webpage</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingHttp -Target "evotec.xyz" -SimpleLocations "Krakow+PL"</dev:code>
+        <dev:remarks>
+          <maml:para>Returns HTTP response details from the Krakow probe.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Headers only</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingHttp -Target "https://example.com" -HeadersOnly</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs only the HTTP headers from each probe.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-GlobalpingMtr</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>GlobalpingMtr</command:noun>
+      <maml:description>
+        <maml:para>Start an MTR (My Traceroute) measurement using Globalping.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Combines ping and traceroute information from multiple probes.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-GlobalpingMtr</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Classic</maml:name>
+          <maml:description>
+            <maml:para>The text output mirrors the behaviour of the MTR command line tool.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>InProgressUpdates</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Locations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+          <dev:type>
+            <maml:name>LocationRequest[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Options</maml:name>
+          <maml:description>
+            <maml:para>Use to configure packet count or other low level parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MtrOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>MtrOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Useful when converting the result to custom objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReuseLocationsFromId</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SimpleLocations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitTime</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Classic</maml:name>
+        <maml:description>
+          <maml:para>The text output mirrors the behaviour of the MTR command line tool.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>InProgressUpdates</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Locations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+        <dev:type>
+          <maml:name>LocationRequest[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Options</maml:name>
+        <maml:description>
+          <maml:para>Use to configure packet count or other low level parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MtrOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>MtrOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Useful when converting the result to custom objects.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReuseLocationsFromId</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SimpleLocations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitTime</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.MtrHopResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.MeasurementResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Some paths may change during the test, affecting hop statistics.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Run MTR against a host</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingMtr -Target "evotec.xyz"</dev:code>
+        <dev:remarks>
+          <maml:para>Produces hop statistics for the target.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Limit packets</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingMtr -Target "example.com" -Options @{ Packets = 3 }</dev:code>
+        <dev:remarks>
+          <maml:para>Configures the probe to send three packets per hop.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-GlobalpingPing</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>GlobalpingPing</command:noun>
+      <maml:description>
+        <maml:para>Start a ping measurement using Globalping.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Instructs remote probes to send ICMP echo requests to the specified target.</maml:para>
+      <maml:para>The cmdlet outputs PingTimingResult objects, raw results or classic text depending on the selected parameters.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-GlobalpingPing</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Classic</maml:name>
+          <maml:description>
+            <maml:para>Each probe returns the textual output of its ping utility.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>InProgressUpdates</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Locations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+          <dev:type>
+            <maml:name>LocationRequest[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Options</maml:name>
+          <maml:description>
+            <maml:para>Use this to configure packet count or other low level settings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PingOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>PingOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>When set the cmdlet outputs the MeasurementResponse object returned by the API.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReuseLocationsFromId</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SimpleLocations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitTime</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Classic</maml:name>
+        <maml:description>
+          <maml:para>Each probe returns the textual output of its ping utility.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>InProgressUpdates</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Locations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+        <dev:type>
+          <maml:name>LocationRequest[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Options</maml:name>
+        <maml:description>
+          <maml:para>Use this to configure packet count or other low level settings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PingOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>PingOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>When set the cmdlet outputs the MeasurementResponse object returned by the API.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReuseLocationsFromId</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SimpleLocations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitTime</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.PingTimingResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.MeasurementResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Some networks block ICMP traffic which may affect results.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Ping from multiple locations</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingPing -Target "evotec.xyz" -SimpleLocations "DE", "US"</dev:code>
+        <dev:remarks>
+          <maml:para>Runs ping from probes in Germany and the United States.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Request five packets</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingPing -Target "example.com" -SimpleLocations "PL" -Options @{ Packets = 5 }</dev:code>
+        <dev:remarks>
+          <maml:para>Uses PingOptions to set the packet count.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Output classic text</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingPing -Target "example.com" -Classic</dev:code>
+        <dev:remarks>
+          <maml:para>Displays the raw ping output returned by the probe.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Start-GlobalpingTraceroute</command:name>
+      <command:verb>Start</command:verb>
+      <command:noun>GlobalpingTraceroute</command:noun>
+      <maml:description>
+        <maml:para>Start a traceroute measurement using Globalping.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Collects hop information from remote probes with optional classic text output.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Start-GlobalpingTraceroute</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+          <maml:name>ApiKey</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Classic</maml:name>
+          <maml:description>
+            <maml:para>Returns the text produced by the traceroute utility.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>InProgressUpdates</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Locations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+          <dev:type>
+            <maml:name>LocationRequest[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Options</maml:name>
+          <maml:description>
+            <maml:para>Allows packet size or protocol customization.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">TracerouteOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>TracerouteOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>The object is not converted to individual hops.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReuseLocationsFromId</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SimpleLocations</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Target</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitTime</maml:name>
+          <maml:description>
+            <maml:para></maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
+        <maml:name>ApiKey</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Classic</maml:name>
+        <maml:description>
+          <maml:para>Returns the text produced by the traceroute utility.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>InProgressUpdates</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Locations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
+        <dev:type>
+          <maml:name>LocationRequest[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Options</maml:name>
+        <maml:description>
+          <maml:para>Allows packet size or protocol customization.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">TracerouteOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>TracerouteOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="AsRaw">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>The object is not converted to individual hops.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReuseLocationsFromId</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SimpleLocations</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Target</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitTime</maml:name>
+        <maml:description>
+          <maml:para></maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.TracerouteHopResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>Globalping.MeasurementResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Intermediate hops may drop packets, resulting in missing data.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Traceroute to a host</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingTraceroute -Target "evotec.xyz"</dev:code>
+        <dev:remarks>
+          <maml:para>Performs traceroute to the target host.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Return raw output</maml:title>
+        <dev:code>PS&gt; Start-GlobalpingTraceroute -Target "example.com" -Classic</dev:code>
+        <dev:remarks>
+          <maml:para>Writes the traceroute text produced by the probe.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://learn.microsoft.com/powershell/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText />
+        <maml:uri>https://github.com/EvotecIT/Globalping</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+</helpItems>

--- a/Module/en-US/Globalping-help.xml
+++ b/Module/en-US/Globalping-help.xml
@@ -261,7 +261,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Anonymous requests may be rate limited.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -285,7 +285,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>InProgressUpdates</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -297,11 +297,11 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Limit</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -309,7 +309,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Locations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
           <dev:type>
@@ -345,7 +345,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>ReuseLocationsFromId</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Reuse probe locations from a previous measurement.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -357,7 +357,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>SimpleLocations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -369,7 +369,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Target</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -381,7 +381,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>WaitTime</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -396,7 +396,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
         <maml:name>ApiKey</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Anonymous requests may be rate limited.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -420,7 +420,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>InProgressUpdates</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -432,11 +432,11 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Limit</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -444,7 +444,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Locations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
         <dev:type>
@@ -480,7 +480,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>ReuseLocationsFromId</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Reuse probe locations from a previous measurement.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -492,7 +492,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>SimpleLocations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -504,7 +504,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Target</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -516,7 +516,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>WaitTime</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -601,7 +601,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Anonymous requests may be rate limited.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -637,7 +637,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>InProgressUpdates</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -649,11 +649,11 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Limit</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -661,7 +661,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Locations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
           <dev:type>
@@ -697,7 +697,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>ReuseLocationsFromId</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Reuse probe locations from a previous measurement.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -709,7 +709,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>SimpleLocations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -721,7 +721,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Target</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -733,7 +733,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>WaitTime</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -748,7 +748,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
         <maml:name>ApiKey</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Anonymous requests may be rate limited.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -784,7 +784,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>InProgressUpdates</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -796,11 +796,11 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Limit</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -808,7 +808,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Locations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
         <dev:type>
@@ -844,7 +844,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>ReuseLocationsFromId</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Reuse probe locations from a previous measurement.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -856,7 +856,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>SimpleLocations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -868,7 +868,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Target</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -880,7 +880,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>WaitTime</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -965,7 +965,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Anonymous requests may be rate limited.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -989,7 +989,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>InProgressUpdates</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -1001,11 +1001,11 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Limit</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1013,7 +1013,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Locations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
           <dev:type>
@@ -1049,7 +1049,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>ReuseLocationsFromId</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Reuse probe locations from a previous measurement.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1061,7 +1061,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>SimpleLocations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -1073,7 +1073,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Target</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -1085,7 +1085,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>WaitTime</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -1100,7 +1100,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
         <maml:name>ApiKey</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Anonymous requests may be rate limited.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1124,7 +1124,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>InProgressUpdates</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1136,11 +1136,11 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Limit</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1148,7 +1148,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Locations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
         <dev:type>
@@ -1184,7 +1184,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>ReuseLocationsFromId</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Reuse probe locations from a previous measurement.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1196,7 +1196,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>SimpleLocations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -1208,7 +1208,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Target</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -1220,7 +1220,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>WaitTime</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -1306,7 +1306,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Anonymous requests may be rate limited.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1330,7 +1330,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>InProgressUpdates</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -1342,11 +1342,11 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Limit</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1354,7 +1354,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Locations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
           <dev:type>
@@ -1390,7 +1390,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>ReuseLocationsFromId</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Reuse probe locations from a previous measurement.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1402,7 +1402,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>SimpleLocations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -1414,7 +1414,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Target</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -1426,7 +1426,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>WaitTime</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -1441,7 +1441,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
         <maml:name>ApiKey</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Anonymous requests may be rate limited.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1465,7 +1465,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>InProgressUpdates</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1477,11 +1477,11 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Limit</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1489,7 +1489,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Locations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
         <dev:type>
@@ -1525,7 +1525,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>ReuseLocationsFromId</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Reuse probe locations from a previous measurement.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1537,7 +1537,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>SimpleLocations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -1549,7 +1549,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Target</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -1561,7 +1561,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>WaitTime</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -1653,7 +1653,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
           <maml:name>ApiKey</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Anonymous requests may be rate limited.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1677,7 +1677,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>InProgressUpdates</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -1689,11 +1689,11 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Limit</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1701,7 +1701,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Locations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
           <dev:type>
@@ -1737,7 +1737,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>ReuseLocationsFromId</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Reuse probe locations from a previous measurement.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -1749,7 +1749,7 @@
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>SimpleLocations</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -1761,7 +1761,7 @@
         <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Target</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -1773,7 +1773,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>WaitTime</maml:name>
           <maml:description>
-            <maml:para></maml:para>
+            <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -1788,7 +1788,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Token">
         <maml:name>ApiKey</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Anonymous requests may be rate limited.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1812,7 +1812,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>InProgressUpdates</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>When set the API streams partial results that are written as they arrive.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -1824,11 +1824,11 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Limit</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>If omitted the cmdlet estimates a value based on provided locations.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1836,7 +1836,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Locations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each LocationRequest may specify city, country, ASN or provider details.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">LocationRequest[]</command:parameterValue>
         <dev:type>
@@ -1872,7 +1872,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>ReuseLocationsFromId</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Reuse probe locations from a previous measurement.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -1884,7 +1884,7 @@
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>SimpleLocations</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Two-letter strings are treated as ISO country codes. Longer values map to the "magic" location syntax used by the API.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -1896,7 +1896,7 @@
       <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Target</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Each value is passed verbatim to the underlying measurement API.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -1908,7 +1908,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>WaitTime</maml:name>
         <maml:description>
-          <maml:para></maml:para>
+          <maml:para>Only applies when InProgressUpdates is specified.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>


### PR DESCRIPTION
## Summary

- Removes the MatejKafka.XmlDoc2CmdletDoc dependency and its build targets.
- Uses the public PSPublishModule 3.0.88 / PowerForge documentation owner.
- Regenerates Markdown and MAML and keeps binary external help discoverable with the assembly-named alias.

## Validation

- Full public-package module build completed.
- Markdown and MAML command identities match; MAML parses as XML.
- Regeneration is idempotent.
- Generated help was exercised through PowerShell 7 and Windows PowerShell 5.1.
- Repository-native .NET builds pass for the supported target frameworks.

## Scope

This PR is intentionally limited to dependency removal and functional build/package/import/Get-Help preservation. Documentation-content debt such as prose, examples, defaults, output annotations, and display enrichment is recorded separately and is not hand-edited in generated artifacts here.